### PR TITLE
Incremental update

### DIFF
--- a/build/compile.bat
+++ b/build/compile.bat
@@ -21,6 +21,7 @@ mplc.exe -D COMPILER_SOURCE_VERSION=%SOURCE_VERSION% -D DEBUG=TRUE -ndebug -o mp
  ../variable.mpl^
  ../sl/Array.mpl^
  ../sl/control.mpl^
+ ../sl/conventions.mpl^
  ../sl/file.mpl^
  ../sl/HashTable.mpl^
  ../sl/memory.mpl^

--- a/build/compile.bat
+++ b/build/compile.bat
@@ -9,6 +9,7 @@ mplc.exe -D COMPILER_SOURCE_VERSION=%SOURCE_VERSION% -D DEBUG=TRUE -ndebug -o mp
  ../builtins.mpl^
  ../codeNode.mpl^
  ../debugWriter.mpl^
+ ../defaultImpl.mpl^
  ../irWriter.mpl^
  ../main.mpl^
  ../parser.mpl^

--- a/build/compile.sh
+++ b/build/compile.sh
@@ -21,6 +21,7 @@ mplc -D COMPILER_SOURCE_VERSION=$SOURCE_VERSION -D DEBUG=TRUE -ndebug -o mplc.ll
  ../variable.mpl\
  ../sl/Array.mpl\
  ../sl/control.mpl\
+ ../sl/conventions.mpl\
  ../sl/file.mpl\
  ../sl/HashTable.mpl\
  ../sl/memory.mpl\

--- a/build/compile.sh
+++ b/build/compile.sh
@@ -9,6 +9,7 @@ mplc -D COMPILER_SOURCE_VERSION=$SOURCE_VERSION -D DEBUG=TRUE -ndebug -o mplc.ll
  ../builtins.mpl\
  ../codeNode.mpl\
  ../debugWriter.mpl\
+ ../defaultImpl.mpl\
  ../irWriter.mpl\
  ../main.mpl\
  ../parser.mpl\

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1008,7 +1008,7 @@ mplBuiltinCodeRef: [
       gnr: nullNode.varNameInfo getName;
       cnr: gnr captureName;
       refToVar: cnr.refToVar copy;
-      #("coderef captured var=" refToVar.hostId ":" refToVar.varId " g=" refToVar isGlobal) addLog
+      #("coderef captured var=" refToVar.hostId ":" refToVar.varId " s=" refToVar staticnessOfVar) addLog
 
       refToVar push
     ]

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1,6 +1,25 @@
 "builtinImpl" module
 "control" includeModule
 
+"codeNode" includeModule
+"processSubNodes" includeModule
+"defaultImpl" includeModule
+
+declareBuiltin: [
+  declareBuiltinName:;
+  declareBuiltinBody:;
+
+  {processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref;} () {} [
+    processorResult:;
+    processor:;
+    copy indexOfNode:;
+    currentNode:;
+    multiParserResult:;
+    failProc: @failProcForProcessor;
+    @declareBuiltinBody ucall
+  ] declareBuiltinName exportFunction
+];
+
 staticnessOfBinResult: [
   s1:; s2:;
   s1 Dynamic > not s2 Dynamic > not or [
@@ -71,33 +90,33 @@ mplNumberBinaryOp: [
   ] when
 ] func;
 
-mplBuiltinAdd: [
+[
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fadd" makeStringView]["add" makeStringView] if] [+] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinAdd" declareBuiltin ucall
 
-mplBuiltinSub: [
+[
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fsub" makeStringView]["sub" makeStringView] if] [-] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinSub" declareBuiltin ucall
 
-mplBuiltinMul: [
+[
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fmul" makeStringView]["mul" makeStringView] if] [*] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinMul" declareBuiltin ucall
 
-mplBuiltinDiv: [
+[
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fdiv" makeStringView][a2 isNat ["udiv" makeStringView] ["sdiv" makeStringView] if] if] [/] [copy] [
     y:; x:;
     y y - y = ["division by zero" compilerError] when
   ] mplNumberBinaryOp
-] func;
+] "mplBuiltinDiv" declareBuiltin ucall
 
-mplBuiltinMod: [
+[
   VarNat8 VarIntX 1 + [a2:; a1:; a2 isNat ["urem" makeStringView] ["srem" makeStringView] if] [mod] [copy] [
     y:; x:;
     y y - y = ["division by zero" compilerError] when
   ] mplNumberBinaryOp
-] func;
+] "mplBuiltinMod" declareBuiltin ucall
 
-mplBuiltinEqual: [
+[
   arg2: pop;
   arg1: pop;
 
@@ -162,19 +181,19 @@ mplBuiltinEqual: [
       ] if
     ] when
   ] when
-] func;
+] "mplBuiltinEqual" declareBuiltin ucall
 
-mplBuiltinLess: [
+[
   VarNat8 VarReal64 1 + [
     a2:; a1:; a2 isReal ["fcmp olt" makeStringView][a2 isNat ["icmp ult" makeStringView] ["icmp slt" makeStringView] if] if
   ] [<] [t:; VarCond] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinLess" declareBuiltin ucall
 
-mplBuiltinGreater: [
+[
   VarNat8 VarReal64 1 + [
     a2:; a1:; a2 isReal ["fcmp ogt" makeStringView][a2 isNat ["icmp ugt" makeStringView] ["icmp sgt" makeStringView] if] if
   ] [>] [t:; VarCond] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinGreater" declareBuiltin ucall
 
 mplNumberUnaryOp: [
   exValidator:;
@@ -221,44 +240,44 @@ mplNumberUnaryOp: [
   ] when
 ] func;
 
-mplBuiltinNot: [
+[
   VarCond VarNatX 1 + [a:; "xor" makeStringView] [
     a:; a getVar.data.getTag VarCond = ["true, " makeStringView]["-1, " makeStringView] if
   ] [not] [x:;] mplNumberUnaryOp
-] func;
+] "mplBuiltinNot" declareBuiltin ucall
 
-mplBuiltinXor: [
+[
   VarCond VarNatX 1 + [a2:; a1:; "xor" makeStringView] [xor] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinXor" declareBuiltin ucall
 
-mplBuiltinAnd: [
+[
   VarCond VarNatX 1 + [a2:; a1:; "and" makeStringView] [and] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinAnd" declareBuiltin ucall
 
-mplBuiltinOr: [
+[
   VarCond VarNatX 1 + [a2:; a1:; "or" makeStringView] [or] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinOr" declareBuiltin ucall
 
-mplBuiltinTrue: [
+[
   TRUE VarCond createVariable createPlainIR push
-] func;
+] "mplBuiltinTrue" declareBuiltin ucall
 
-mplBuiltinFalse: [
+[
   FALSE VarCond createVariable createPlainIR push
-] func;
+] "mplBuiltinFalse" declareBuiltin ucall
 
-mplBuiltinLF: [
+[
   s: LF toString;
   s VarString createVariable createStringIR push
-] func;
+] "mplBuiltinLF" declareBuiltin ucall
 
-mplBuiltinNeg: [
+[
   VarInt8 VarReal64 1 + [
     a:; a isAnyInt ["sub" makeStringView]["fsub" makeStringView] if
   ] [
     a:; a isAnyInt ["0, " makeStringView]["0x0000000000000000, " makeStringView] if
   ] [neg] [x:;] mplNumberUnaryOp
-] func;
+] "mplBuiltinNeg" declareBuiltin ucall
 
 mplNumberBuiltinOp: [
   exValidator:;
@@ -313,49 +332,49 @@ mplNumberBuiltinOp: [
   ] when
 ] func;
 
-mplBuiltinSin: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.sin.f32" makeStringView]["@llvm.sin.f64" makeStringView] if
   ] [sin] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinSin" declareBuiltin ucall
 
-mplBuiltinCos: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.cos.f32" makeStringView]["@llvm.cos.f64" makeStringView] if
   ] [cos] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinCos" declareBuiltin ucall
 
-mplBuiltinSqrt: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.sqrt.f32" makeStringView]["@llvm.sqrt.f64" makeStringView] if
   ] [sqrt] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinSqrt" declareBuiltin ucall
 
-mplBuiltinCeil: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.ceil.f32" makeStringView]["@llvm.ceil.f64" makeStringView] if
   ] [ceil] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinCeil" declareBuiltin ucall
 
-mplBuiltinFloor: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.floor.f32" makeStringView]["@llvm.floor.f64" makeStringView] if
   ] [floor] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinFloor" declareBuiltin ucall
 
-mplBuiltinLog: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.log.f32" makeStringView]["@llvm.log.f64" makeStringView] if
   ] [log] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinLog" declareBuiltin ucall
 
-mplBuiltinLog10: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.log10.f32" makeStringView]["@llvm.log10.f64" makeStringView] if
   ] [log10] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinLog10" declareBuiltin ucall
 
-mplBuiltinPow: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   arg2: pop;
   arg1: pop;
@@ -416,7 +435,7 @@ mplBuiltinPow: [
       ] if
     ] when
   ] when
-] func;
+] "mplBuiltinPow" declareBuiltin ucall
 
 mplShiftBinaryOp: [
   opFunc:;
@@ -474,63 +493,19 @@ mplShiftBinaryOp: [
   ] when
 ] func;
 
-mplBuiltinLShift: [
+[
   [t2:; t1:; "shl" makeStringView][lshift] mplShiftBinaryOp
-] func;
+] "mplBuiltinLShift" declareBuiltin ucall
 
-mplBuiltinRShift: [
+[
   [t2:; t1:; t1 isNat ["lshr" makeStringView]["ashr" makeStringView] if][rshift] mplShiftBinaryOp
-] func;
+] "mplBuiltinRShift" declareBuiltin ucall
 
-createRef: [
-  mutable:;
-  refToVar:;
-  refToVar isVirtual [
-    refToVar untemporize
-    refToVar copy #for dropping or getting callables for example
-  ] [
-    var: refToVar getVar;
-    #var.temporary [var.data.getTag VarRef = not] && [
-    #  "getting ref to temporary var" compilerError
-    #] [
-    refToVar staticnessOfVar Weak = [Dynamic @var.@staticness set] when
-    refToVar fullUntemporize
+[TRUE defaultRef] "mplBuiltinRef" declareBuiltin ucall
+[FALSE defaultRef] "mplBuiltinCref" declareBuiltin ucall
+[TRUE defaultMakeConstWith] "mplBuiltinConst" declareBuiltin ucall
 
-    newRefToVar: refToVar VarRef createVariable;
-    mutable refToVar.mutable and @newRefToVar.@mutable set
-    refToVar newRefToVar createRefOperation
-    newRefToVar
-    #] if
-  ] if
-] func;
-
-mplProcessRef: [
-  copy mutable:;
-  refToVar: pop;
-  compilable [
-    refToVar mutable createRef push
-  ] when
-] func;
-
-mplBuiltinRef: [TRUE mplProcessRef] func;
-mplBuiltinCref: [FALSE mplProcessRef] func;
-
-mplBuiltinConstWith: [
-  copy check:;
-  refToVar: pop;
-  compilable [
-    check [refToVar getVar.temporary copy] && [
-      "temporary objects cannot be set const" compilerError
-    ] [
-      FALSE @refToVar.@mutable set
-      refToVar push
-    ] if
-  ] when
-] func;
-
-mplBuiltinConst: [TRUE mplBuiltinConstWith] func;
-
-mplBuiltinDeref: [
+[
   refToVar: pop;
   compilable [
     refToVar getVar.data.getTag VarRef = [
@@ -543,29 +518,13 @@ mplBuiltinDeref: [
       "not a reference" makeStringView compilerError
     ] if
   ] when
-] func;
+] "mplBuiltinDeref" declareBuiltin ucall
 
-mplBuiltinCall: [
-  refToVar: pop;
-  compilable [
-    var: refToVar getVar;
-    var.data.getTag VarCode = [
-      VarCode var.data.get "call" makeStringView processCall
-    ] [
-      var.data.getTag VarImport = [
-        refToVar processFuncPtr
-      ] [
-        refToVar isCallable [
-          RefToVar refToVar "call" makeStringView callCallableStruct # call struct with INVALID object
-        ] [
-          "not callable" makeStringView compilerError
-        ] if
-      ] if
-    ] if
-  ] when
-] func;
+[
+  defaultCall
+] "mplBuiltinCall" declareBuiltin ucall
 
-mplBuiltinUcall: [
+[
   code: pop;
 
   compilable [
@@ -581,63 +540,33 @@ mplBuiltinUcall: [
       indexArray addIndexArrayToProcess
     ] when
   ] when
-] func;
+] "mplBuiltinUcall" declareBuiltin ucall
 
-mplBuiltinDynamic: [
+[
   refToVar: pop;
   compilable [
     refToVar makeVarTreeDynamic
     refToVar push
   ] when
-] func;
+] "mplBuiltinDynamic" declareBuiltin ucall
 
-mplBuiltinDirty: [
+[
   refToVar: pop;
   compilable [
     refToVar makeVarTreeDirty
     refToVar push
   ] when
-] func;
+] "mplBuiltinDirty" declareBuiltin ucall
 
-mplBuiltinStatic: [
+[
   refToVar: pop;
   compilable [
     refToVar staticnessOfVar Weak = [refToVar Static makeStaticness @refToVar set] when
     refToVar push
   ] when
-] func;
+] "mplBuiltinStatic" declareBuiltin ucall
 
-mplBuiltinSet: [
-  refToDst: pop;
-  refToSrc: pop;
-
-  compilable [
-    refToDst refToSrc variablesAreSame [
-      refToSrc getVar.data.getTag VarImport = [
-        "functions cannot be copied" compilerError
-      ] [
-        refToDst.mutable [
-          [refToDst staticnessOfVar Weak = not] "Destination is weak!" assert
-          refToSrc refToDst createCopyToExists
-        ] [
-          "destination is immutable" compilerError
-        ] if
-      ] if
-    ] [
-      refToDst.mutable not [
-        "destination is immutable" compilerError
-      ] [
-        lambdaCastResult: refToSrc refToDst tryImplicitLambdaCast;
-        lambdaCastResult.success [
-          newSrc: lambdaCastResult.refToVar TRUE createRef;
-          newSrc refToDst createCopyToExists
-        ] [
-          ("types mismatch, src is " refToSrc getMplType "," LF "dst is " refToDst getMplType) assembleString compilerError
-        ] if
-      ] if
-    ] if
-  ] when
-] func;
+[defaultSet] "mplBuiltinSet" declareBuiltin ucall
 
 mplBuiltinProcessAtList: [
   refToStruct: pop;
@@ -733,21 +662,21 @@ mplBuiltinProcessAtList: [
   result
 ] func;
 
-mplBuiltinAt: [
+[
   field: mplBuiltinProcessAtList;
   compilable [
     field derefAndPush
   ] when
-] func;
+] "mplBuiltinAt" declareBuiltin ucall
 
-mplBuiltinExclamation: [
+[
   field: mplBuiltinProcessAtList;
   compilable [
     field setRef
   ] when
-] func;
+] "mplBuiltinExclamation" declareBuiltin ucall
 
-mplBuiltinIf: [
+[
   else: pop;
   then: pop;
   condition: pop;
@@ -777,9 +706,9 @@ mplBuiltinIf: [
       ] if
     ] when
   ] when
-] func;
+] "mplBuiltinIf" declareBuiltin ucall
 
-mplBuiltinUif: [
+[
   else: pop;
   then: pop;
   condition: pop;
@@ -806,9 +735,9 @@ mplBuiltinUif: [
       ] if
     ] when
   ] when
-] func;
+] "mplBuiltinUif" declareBuiltin ucall
 
-mplBuiltinLoop: [
+[
   body: pop;
 
   (
@@ -821,7 +750,7 @@ mplBuiltinLoop: [
       astNode processLoop
     ]
   ) sequence
-] func;
+] "mplBuiltinLoop" declareBuiltin ucall
 
 parseFieldToSignatureCaptureArray: [
   refToStruct:;
@@ -912,7 +841,7 @@ parseSignature: [
   result
 ] func;
 
-mplBuiltinExportFunction: [
+[
   (
     [compilable]
     [currentNode.parent 0 = not ["export must be global" compilerError] when]
@@ -933,9 +862,9 @@ mplBuiltinExportFunction: [
       index: signature astNode VarString varName.data.get makeStringView FALSE dynamic processExportFunction;
     ]
   ) sequence
-] func;
+] "mplBuiltinExportFunction" declareBuiltin ucall
 
-mplBuiltinExportVariable: [
+[
   (
     [compilable]
     [currentNode.parent 0 = not ["export must be global" compilerError] when]
@@ -977,9 +906,9 @@ mplBuiltinExportVariable: [
       ] when
     ]
   ) sequence
-] func;
+] "mplBuiltinExportVariable" declareBuiltin ucall
 
-mplBuiltinImportFunction: [
+[
   (
     [compilable]
     [currentNode.parent 0 = not ["import must be global" compilerError] when]
@@ -992,9 +921,9 @@ mplBuiltinImportFunction: [
     [signature: parseSignature;]
     [index: signature VarString varName.data.get makeStringView FALSE dynamic processImportFunction;]
   ) sequence
-] func;
+] "mplBuiltinImportFunction" declareBuiltin ucall
 
-mplBuiltinCodeRef: [
+[
   (
     [compilable]
     [signature: parseSignature;]
@@ -1013,9 +942,9 @@ mplBuiltinCodeRef: [
       refToVar push
     ]
   ) sequence
-] func;
+] "mplBuiltinCodeRef" declareBuiltin ucall
 
-mplBuiltinImportVariable: [
+[
   currentNode.parent 0 = not ["import must be global" compilerError] when
   compilable [
     refToName: pop;
@@ -1056,9 +985,9 @@ mplBuiltinImportVariable: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinImportVariable" declareBuiltin ucall
 
-mplBuiltinCopy: [
+[
   refToVar: pop;
   compilable [
     refToVar getVar.temporary [
@@ -1079,9 +1008,9 @@ mplBuiltinCopy: [
       ] if
     ] if
   ] when
-] func;
+] "mplBuiltinCopy" declareBuiltin ucall
 
-mplBuiltinNewVarOfTheSameType: [
+[
   refToVar: pop;
   compilable [
     result: refToVar copyVarToNew;
@@ -1092,9 +1021,9 @@ mplBuiltinNewVarOfTheSameType: [
 
     result push
   ] when
-] func;
+] "mplBuiltinNewVarOfTheSameType" declareBuiltin ucall
 
-mplBuiltinCast: [
+[
   refToSchema: pop;
   refToVar: pop;
 
@@ -1185,9 +1114,9 @@ mplBuiltinCast: [
       "can cast only numbers" compilerError
     ] if
   ] when
-] func;
+] "mplBuiltinCast" declareBuiltin ucall
 
-mplBuiltinStorageAddress: [
+[
   (
     [compilable]
     [refToVar: pop;]
@@ -1206,9 +1135,9 @@ mplBuiltinStorageAddress: [
       refToDst push
     ]
   ) sequence
-] func;
+] "mplBuiltinStorageAddress" declareBuiltin ucall
 
-mplBuiltinAddressToReference: [
+[
   refToSchema: pop;
   refToVar: pop;
 
@@ -1257,25 +1186,25 @@ mplBuiltinAddressToReference: [
       "address must be a NatX" compilerError
     ] if
   ] when
-] func;
+] "mplBuiltinAddressToReference" declareBuiltin ucall
 
-mplBuiltinConstVar: [
+[
   currentNode.nextLabelIsConst ["duplicate virtual specifier" compilerError] when
   TRUE @currentNode.@nextLabelIsConst set
-] func;
+] "mplBuiltinConstVar" declareBuiltin ucall
 
-mplBuiltinVirtual: [
+[
   currentNode.nextLabelIsVirtual ["duplicate virtual specifier" compilerError] when
   TRUE @currentNode.@nextLabelIsVirtual set
-] func;
+] "mplBuiltinVirtual" declareBuiltin ucall
 
-mplBuiltinSchema: [
+[
   currentNode.nextLabelIsSchema ["duplicate schema specifier" compilerError] when
   TRUE @currentNode.@nextLabelIsSchema set
-] func;
+] "mplBuiltinSchema" declareBuiltin ucall
 
-mplBuiltinModule: [
-  parentIndex 0 = not [
+[
+  currentNode.parent 0 = not [
     "module can be declared only in top node" makeStringView compilerError
   ] [
     refToName: pop;
@@ -1307,90 +1236,12 @@ mplBuiltinModule: [
       ] when
     ] when
   ] if
-] func;
+] "mplBuiltinModule" declareBuiltin ucall
 
-addNamesFromModule: [
-  copy moduleId:;
+[TRUE dynamic defaultUseOrIncludeModule] "mplBuiltinUseModule" declareBuiltin ucall
+[FALSE dynamic defaultUseOrIncludeModule] "mplBuiltinIncludeModule" declareBuiltin ucall
 
-  fru: current currentNode.usedOrIncludedModulesTable.find;
-  fru.success not [
-    moduleId TRUE @currentNode.@usedOrIncludedModulesTable.insert
-
-    moduleNode: moduleId processor.nodes.at.get;
-    moduleNode.labelNames [
-      current: .value;
-      current.nameInfo current.refToVar addOverloadForPre
-      current.nameInfo current.refToVar NameCaseFromModule addNameInfo #it is not own local variable
-    ] each
-  ] when
-] func;
-
-processUseModule: [
-  copy asUse:;
-  copy moduleId:;
-
-  currentModule: moduleId processor.nodes.at.get;
-  moduleList: currentModule.includedModules copy;
-  moduleId @moduleList.pushBack
-
-  moduleList [
-    pair:;
-    current: pair.value;
-    #("try include module with id " current " name " current processor.nodes.at.get.moduleName) addLog
-    last: pair.index moduleList.getSize 1 - =;
-
-    asUse [last copy] && [
-      current {used: FALSE dynamic; position: currentNode.position copy;} @currentNode.@usedModulesTable.insert
-      current TRUE @currentNode.@directlyIncludedModulesTable.insert
-      current addNamesFromModule
-    ] [
-      fr: current currentNode.includedModulesTable.find;
-      fr.success not [
-        last [
-          current TRUE @currentNode.@directlyIncludedModulesTable.insert
-        ] when
-        current @currentNode.@includedModules.pushBack
-        current {used: FALSE dynamic; position: currentNode.position copy;} @currentNode.@includedModulesTable.insert
-        current addNamesFromModule
-      ] when
-    ] if
-  ] each
-] func;
-
-mplBuiltinUseOrIncludeModule: [
-  copy asUse:;
-  (
-    [compilable]
-    [parentIndex 0 = not ["module can be used only in top node" compilerError] when]
-    [refToName: pop;]
-    [refToName staticnessOfVar Weak < ["name must be static string" compilerError] when]
-    [
-      varName: refToName getVar;
-      varName.data.getTag VarString = not ["name must be static string" compilerError] when
-    ] [
-      string: VarString varName.data.get;
-      fr: string makeStringView processor.modules.find;
-      fr.success [fr.value 0 < not] && [
-        frn: fr.value currentNode.usedModulesTable.find;
-        frn2: fr.value currentNode.directlyIncludedModulesTable.find;
-        frn.success frn2.success or [
-          ("duplicate use module: " string) assembleString compilerError
-        ] [
-          fr.value asUse processUseModule
-        ] if
-      ] [
-        TRUE dynamic @processorResult.@findModuleFail set
-        string @processorResult.@errorInfo.@missedModule set
-        ("module not found: " string) assembleString compilerError
-      ] if
-    ]
-  ) sequence
-] func;
-
-mplBuiltinUseModule: [TRUE dynamic mplBuiltinUseOrIncludeModule] func;
-mplBuiltinIncludeModule: [FALSE dynamic mplBuiltinUseOrIncludeModule] func;
-
-mplBuiltinTextSize: [
+[
   refToName: pop;
   compilable [
     refToName staticnessOfVar Weak < [
@@ -1407,9 +1258,9 @@ mplBuiltinTextSize: [
       ] when
     ] if
   ] when
-] func;
+] "mplBuiltinTextSize" declareBuiltin ucall
 
-mplBuiltinStrCat: [
+[
   (
     [compilable]
     [refToStr2: pop;]
@@ -1426,9 +1277,9 @@ mplBuiltinStrCat: [
     ]
     [(VarString varStr1.data.get VarString varStr2.data.get) assembleString VarString createVariable createStringIR push]
   ) sequence
-] func;
+] "mplBuiltinStrCat" declareBuiltin ucall
 
-mplBuiltinTextSplit: [
+[
   refToName: pop;
   compilable [
     refToName staticnessOfVar Weak < ["name must be static string" makeStringView compilerError] when
@@ -1488,9 +1339,9 @@ mplBuiltinTextSplit: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinTextSplit" declareBuiltin ucall
 
-mplBuiltinHas: [
+[
   (
     [compilable]
     [refToName: pop;]
@@ -1514,9 +1365,9 @@ mplBuiltinHas: [
       ] if
     ]
   ) sequence
-] func;
+] "mplBuiltinHas" declareBuiltin ucall
 
-mplBuiltinFieldIndex: [
+[
   (
     [compilable]
     [refToName: pop;]
@@ -1539,9 +1390,9 @@ mplBuiltinFieldIndex: [
       fr.index Int64 cast VarInt32 createVariable Static makeStaticness createPlainIR push
     ]
   ) sequence
-] func;
+] "mplBuiltinFieldIndex" declareBuiltin ucall
 
-mplBuiltinDef: [
+[
   (
     [compilable]
     [refToName: pop;]
@@ -1556,9 +1407,9 @@ mplBuiltinDef: [
       VarString varName.data.get findNameInfo pop createNamedVariable
     ]
   ) sequence
-] func;
+] "mplBuiltinDef" declareBuiltin ucall
 
-mplBuiltinStorageSize: [
+[
   refToVar: pop;
   compilable [
     refToVar isVirtual [
@@ -1578,9 +1429,9 @@ mplBuiltinStorageSize: [
 
     0n64 cast VarNatX createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinStorageSize" declareBuiltin ucall
 
-mplBuiltinAlignment: [
+[
   refToVar: pop;
   compilable [
     refToVar isVirtual [
@@ -1600,9 +1451,9 @@ mplBuiltinAlignment: [
 
     0n64 cast VarNatX createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinAlignment" declareBuiltin ucall
 
-mplBuiltinPrintCompilerMessage: [
+[
   refToName: pop;
   compilable [
     refToName staticnessOfVar Weak < ["name must be static string" makeStringView compilerError] when
@@ -1614,57 +1465,31 @@ mplBuiltinPrintCompilerMessage: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinPrintCompilerMessage" declareBuiltin ucall
 
-mplBuiltinPrintVariableCount: [
+[
   compilable [
     ("var count=" processor.varCount LF) printList
   ] when
-] func;
+] "mplBuiltinPrintVariableCount" declareBuiltin ucall
 
-mplBuiltinPrintStack: [
-  ("stack:" LF "depth=" getStackDepth LF) printList
+[
+  defaultPrintStack
+] "mplBuiltinPrintStack" declareBuiltin ucall
 
-  i: 0 dynamic;
-  [
-    i getStackDepth < [
-      entry: i getStackEntryUnchecked;
-      (i getStackEntryUnchecked getMplType entry.mutable ["R" makeStringView]["C" makeStringView] if LF) printList
-      i 1 + @i set TRUE
-    ] &&
-  ] loop
-] func;
+[
+  defaultPrintStackTrace
+] "mplBuiltinPrintStackTrace" declareBuiltin ucall
 
-mplBuiltinPrintStackTrace: [
-  nodeIndex: indexOfNode copy;
-  [
-    node: nodeIndex processor.nodes.at.get;
-    node.root [
-      FALSE
-    ] [
-      ("at filename: "  node.position.filename processor.options.fileNames.at
-        ", token: "      node.position.token
-        ", nodeIndex: "  nodeIndex
-        ", line: "       node.position.line
-        ", column: "     node.position.column LF) printList
-
-      node.parent @nodeIndex set
-      TRUE
-    ] if
-  ] loop
-
-  mplBuiltinPrintStack
-] func;
-
-mplBuiltinSame: [
+[
   refToVar1: pop;
   refToVar2: pop;
   compilable [
     refToVar1 refToVar2 variablesAreSame VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinSame" declareBuiltin ucall
 
-mplBuiltinIs: [
+[
   refToVar1: pop;
   refToVar2: pop;
   compilable [
@@ -1680,6 +1505,7 @@ mplBuiltinIs: [
           -1 @cmpResult set
         ] if
       ] if
+
       cmpResult 0 = [
         result: FALSE VarCond createVariable Dynamic makeStaticness createAllocIR;
         refToVar1 refToVar2 result "icmp eq" makeStringView createDirectBinaryOperation
@@ -1691,31 +1517,31 @@ mplBuiltinIs: [
       FALSE VarCond createVariable Static makeStaticness createPlainIR push
     ] if
   ] when
-] func;
+] "mplBuiltinIs" declareBuiltin ucall
 
-mplBuiltinIsConst: [
+[
   refToVar: pop;
   compilable [
     refToVar.mutable not VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinIsConst" declareBuiltin ucall
 
-mplBuiltinIsCombined: [
+[
   refToVar: pop;
   compilable [
     refToVar getVar.data.getTag VarStruct = VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinIsCombined" declareBuiltin ucall
 
-mplBuiltinDebug: [
+[
   processor.options.debug VarCond createVariable Static makeStaticness createPlainIR push
-] func;
+] "mplBuiltinDebug" declareBuiltin ucall
 
-mplBuiltinHasLogs: [
+[
   processor.options.logs VarCond createVariable Static makeStaticness createPlainIR push
-] func;
+] "mplBuiltinHasLogs" declareBuiltin ucall
 
-mplBuiltinFieldCount: [
+[
   refToVar: pop;
   compilable [
     var: refToVar getVar;
@@ -1733,9 +1559,9 @@ mplBuiltinFieldCount: [
       ] when
     ] if
   ] when
-] func;
+] "mplBuiltinFieldCount" declareBuiltin ucall
 
-mplBuiltinFieldName: [
+[
   refToCount: pop;
   refToVar: pop;
   compilable [
@@ -1766,13 +1592,13 @@ mplBuiltinFieldName: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinFieldName" declareBuiltin ucall
 
-mplBuiltinCompilerVersion: [
+[
   COMPILER_SOURCE_VERSION 0i64 cast VarInt32 createVariable Static makeStaticness createPlainIR push
-] func;
+] "mplBuiltinCompilerVersion" declareBuiltin ucall
 
-mplBuiltinArray: [
+[
   refToCount: pop;
   refToElement: pop;
   compilable [
@@ -1833,21 +1659,21 @@ mplBuiltinArray: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinArray" declareBuiltin ucall
 
-mplBuiltinNew: [
+[
   TRUE dynamic @processor.@usedHeapBuiltins set
   refToVar: pop;
-  refToVar createNew push mplBuiltinRef
-] func;
+  refToVar createNew push TRUE defaultRef
+] "mplBuiltinNew" declareBuiltin ucall
 
-mplBuiltinDelete: [
+[
   TRUE dynamic @processor.@usedHeapBuiltins set
   refToVar: pop;
   refToVar createDelete
-] func;
+] "mplBuiltinDelete" declareBuiltin ucall
 
-mplBuiltinMove: [
+[
   refToVar: pop;
   compilable [
     refToVar.mutable [
@@ -1865,9 +1691,9 @@ mplBuiltinMove: [
       "moved can be only mutable variables" makeStringView compilerError
     ] if
   ] when
-] func;
+] "mplBuiltinMove" declareBuiltin ucall
 
-mplBuiltinMoveIf: [
+[
   refToCond: pop;
   compilable [
     condVar: refToCond getVar;
@@ -1896,39 +1722,39 @@ mplBuiltinMoveIf: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinMoveIf" declareBuiltin ucall
 
-mplBuiltinIsMoved: [
+[
   refToVar: pop;
   compilable [
     refToVar push
     refToVar isForgotten
     VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinIsMoved" declareBuiltin ucall
 
-mplBuiltinManuallyInitVariable: [
+[
   refToVar: pop;
   compilable [
     refToVar isAutoStruct [refToVar callInit] when
   ] when
-] func;
+] "mplBuiltinManuallyInitVariable" declareBuiltin ucall
 
-mplBuiltinManuallyDestroyVariable: [
+[
   refToVar: pop;
   compilable [
     refToVar isAutoStruct [refToVar callDie] when
   ] when
-] func;
+] "mplBuiltinManuallyDestroyVariable" declareBuiltin ucall
 
-mplBuiltinCompileOnce: [
+[
   TRUE dynamic @currentNode.@nodeCompileOnce set
-] func;
+] "mplBuiltinCompileOnce" declareBuiltin ucall
 
-mplBuiltinRecursive: [
+[
   TRUE dynamic @currentNode.@nodeIsRecursive set
-] func;
+] "mplBuiltinRecursive" declareBuiltin ucall
 
-mplBuiltinFailProc: [
-  text: pop;
-] func;
+[
+  defaultFailProc
+] "mplBuiltinFailProc" declareBuiltin ucall

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1664,13 +1664,13 @@ parseSignature: [
 [
   TRUE dynamic @processor.@usedHeapBuiltins set
   refToVar: pop;
-  refToVar createNew push TRUE defaultRef
+  compilable [refToVar createNew push TRUE defaultRef] when
 ] "mplBuiltinNew" declareBuiltin ucall
 
 [
   TRUE dynamic @processor.@usedHeapBuiltins set
   refToVar: pop;
-  refToVar createDelete
+  compilable [refToVar createDelete] when
 ] "mplBuiltinDelete" declareBuiltin ucall
 
 [

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -885,24 +885,24 @@ parseSignature: [
     ]
     [
       hasConvention not [
-        "default convention is not implemented" compilerError
-      ] [
-        return: pop;
-        compilable [
-          return isVirtual [
-            returnVar: return getVar;
-            returnVar.data.getTag VarStruct = not [(return getMplType " can not be a return type") assembleString compilerError] when
+        String @result.@convention set
+      ] when
+
+      return: pop;
+      compilable [
+        return isVirtual [
+          returnVar: return getVar;
+          returnVar.data.getTag VarStruct = not [(return getMplType " can not be a return type") assembleString compilerError] when
+        ] [
+          #todo: detect temporality
+          returnVar: return getVar;
+          returnVar.temporary [
+            return @result.@outputs.pushBack
           ] [
-            #todo: detect temporality
-            returnVar: return getVar;
-            returnVar.temporary [
-              return @result.@outputs.pushBack
-            ] [
-              return return.mutable createRef @result.@outputs.pushBack
-            ] if
+            return return.mutable createRef @result.@outputs.pushBack
           ] if
-        ] when
-      ] if
+        ] if
+      ] when
     ]
     [arguments: pop;]
     [

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -919,7 +919,7 @@ parseSignature: [
 mplBuiltinExportFunction: [
   (
     [compilable]
-    [currentNode.parent 0 = not ["import must be global" compilerError] when]
+    [currentNode.parent 0 = not ["export must be global" compilerError] when]
     [refToName: pop;]
     [refToName staticnessOfVar Weak < ["function name must be static string" compilerError] when]
     [
@@ -942,7 +942,7 @@ mplBuiltinExportFunction: [
 mplBuiltinExportVariable: [
   (
     [compilable]
-    [currentNode.parent 0 = not ["import must be global" compilerError] when]
+    [currentNode.parent 0 = not ["export must be global" compilerError] when]
     [refToName: pop;]
     [refToVar: pop;]
     [refToName staticnessOfVar Weak < ["function name must be static string" compilerError] when]

--- a/builtins.mpl
+++ b/builtins.mpl
@@ -1,97 +1,99 @@
 "builtins" module
-"control" useModule
 
-virtual builtins: (
-  ["!"                       ] [mplBuiltinExclamation             ]
-  ["@"                       ] [mplBuiltinAt                      ]
-  ["+"                       ] [mplBuiltinAdd                     ]
-  ["-"                       ] [mplBuiltinSub                     ]
-  ["*"                       ] [mplBuiltinMul                     ]
-  ["/"                       ] [mplBuiltinDiv                     ]
-  ["&"                       ] [mplBuiltinStrCat                  ]
-  ["="                       ] [mplBuiltinEqual                   ]
-  ["<"                       ] [mplBuiltinLess                    ]
-  [">"                       ] [mplBuiltinGreater                 ]
-  ["^"                       ] [mplBuiltinPow                     ]
-  ["~"                       ] [mplBuiltinNot                     ]
+"control" includeModule
+"builtinImpl" includeModule
 
-  ["addressToReference"      ] [mplBuiltinAddressToReference      ]
-  ["alignment"               ] [mplBuiltinAlignment               ]
-  ["and"                     ] [mplBuiltinAnd                     ]
-  ["array"                   ] [mplBuiltinArray                   ]
-  ["call"                    ] [mplBuiltinCall                    ]
-  ["cast"                    ] [mplBuiltinCast                    ]
-  ["ceil"                    ] [mplBuiltinCeil                    ]
-  ["codeRef"                 ] [mplBuiltinCodeRef                 ]
-  ["cos"                     ] [mplBuiltinCos                     ]
-  #["cref"                    ] [mplBuiltinCref                    ]
-  ["compileOnce"             ] [mplBuiltinCompileOnce             ]
-  ["COMPILER_VERSION"        ] [mplBuiltinCompilerVersion         ]
-  ["const"                   ] [mplBuiltinConst                   ]
-  ["copy"                    ] [mplBuiltinCopy                    ]
-  ["DEBUG"                   ] [mplBuiltinDebug                   ]
-  ["def"                     ] [mplBuiltinDef                     ]
-  ["delete"                  ] [mplBuiltinDelete                  ]
-  #["deref"                   ] [mplBuiltinDeref                   ]
-  #["dirty"                   ] [mplBuiltinDirty                   ]
-  ["dynamic"                 ] [mplBuiltinDirty                   ]
-  ["exportFunction"          ] [mplBuiltinExportFunction          ]
-  ["exportVariable"          ] [mplBuiltinExportVariable          ]
-  ["FALSE"                   ] [mplBuiltinFalse                   ]
-  ["failProc"                ] [mplBuiltinFailProc                ]
-  ["fieldCount"              ] [mplBuiltinFieldCount              ]
-  ["fieldIndex"              ] [mplBuiltinFieldIndex              ]
-  ["fieldName"               ] [mplBuiltinFieldName               ]
-  ["floor"                   ] [mplBuiltinFloor                   ]
-  ["has"                     ] [mplBuiltinHas                     ]
-  ["HAS_LOGS"                ] [mplBuiltinHasLogs                 ]
-  ["if"                      ] [mplBuiltinIf                      ]
-  ["is"                      ] [mplBuiltinIs                      ]
-  ["isMoved"                 ] [mplBuiltinIsMoved                 ]
-  ["importFunction"          ] [mplBuiltinImportFunction          ]
-  ["importVariable"          ] [mplBuiltinImportVariable          ]
-  ["includeModule"           ] [mplBuiltinIncludeModule           ]
-  ["isConst"                 ] [mplBuiltinIsConst                 ]
-  ["isCombined"              ] [mplBuiltinIsCombined              ]
-  ["LF"                      ] [mplBuiltinLF                      ]
-  ["log"                     ] [mplBuiltinLog                     ]
-  ["log10"                   ] [mplBuiltinLog10                   ]
-  ["loop"                    ] [mplBuiltinLoop                    ]
-  ["lshift"                  ] [mplBuiltinLShift                  ]
-  ["manuallyInitVariable"    ] [mplBuiltinManuallyInitVariable    ]
-  ["manuallyDestroyVariable" ] [mplBuiltinManuallyDestroyVariable ]
-  ["mod"                     ] [mplBuiltinMod                     ]
-  ["module"                  ] [mplBuiltinModule                  ]
-  ["move"                    ] [mplBuiltinMove                    ]
-  ["moveIf"                  ] [mplBuiltinMoveIf                  ]
-  ["neg"                     ] [mplBuiltinNeg                     ]
-  ["new"                     ] [mplBuiltinNew                     ]
-  ["newVarOfTheSameType"     ] [mplBuiltinNewVarOfTheSameType     ]
-  ["not"                     ] [mplBuiltinNot                     ]
-  ["or"                      ] [mplBuiltinOr                      ]
-  ["printCompilerMessage"    ] [mplBuiltinPrintCompilerMessage    ]
-  ["printStack"              ] [mplBuiltinPrintStack              ]
-  ["printStackTrace"         ] [mplBuiltinPrintStackTrace         ]
-  ["printVariableCount"      ] [mplBuiltinPrintVariableCount      ]
-  ["recursive"               ] [mplBuiltinRecursive               ]
-  #["ref"                     ] [mplBuiltinRef                     ]
-  ["rshift"                  ] [mplBuiltinRShift                  ]
-  ["same"                    ] [mplBuiltinSame                    ]
-  ["schema"                  ] [mplBuiltinSchema                  ]
-  ["set"                     ] [mplBuiltinSet                     ]
-  ["sin"                     ] [mplBuiltinSin                     ]
-  ["sqrt"                    ] [mplBuiltinSqrt                    ]
-  ["static"                  ] [mplBuiltinStatic                  ]
-  ["storageSize"             ] [mplBuiltinStorageSize             ]
-  ["storageAddress"          ] [mplBuiltinStorageAddress          ]
-  ["textSize"                ] [mplBuiltinTextSize                ]
-  ["textSplit"               ] [mplBuiltinTextSplit               ]
-  ["TRUE"                    ] [mplBuiltinTrue                    ]
-  ["uif"                     ] [mplBuiltinUif                     ]
-  ["ucall"                   ] [mplBuiltinUcall                   ]
-  ["useModule"               ] [mplBuiltinUseModule               ]
-  ["virtual"                 ] [mplBuiltinVirtual                 ]
-  ["xor"                     ] [mplBuiltinXor                     ]
+builtins: (
+  {name: "!"                       ; impl: @mplBuiltinExclamation             ;}
+  {name: "@"                       ; impl: @mplBuiltinAt                      ;}
+  {name: "+"                       ; impl: @mplBuiltinAdd                     ;}
+  {name: "-"                       ; impl: @mplBuiltinSub                     ;}
+  {name: "*"                       ; impl: @mplBuiltinMul                     ;}
+  {name: "/"                       ; impl: @mplBuiltinDiv                     ;}
+  {name: "&"                       ; impl: @mplBuiltinStrCat                  ;}
+  {name: "="                       ; impl: @mplBuiltinEqual                   ;}
+  {name: "<"                       ; impl: @mplBuiltinLess                    ;}
+  {name: ">"                       ; impl: @mplBuiltinGreater                 ;}
+  {name: "^"                       ; impl: @mplBuiltinPow                     ;}
+  {name: "~"                       ; impl: @mplBuiltinNot                     ;}
+
+  {name: "addressToReference"      ; impl: @mplBuiltinAddressToReference      ;}
+  {name: "alignment"               ; impl: @mplBuiltinAlignment               ;}
+  {name: "and"                     ; impl: @mplBuiltinAnd                     ;}
+  {name: "array"                   ; impl: @mplBuiltinArray                   ;}
+  {name: "call"                    ; impl: @mplBuiltinCall                    ;}
+  {name: "cast"                    ; impl: @mplBuiltinCast                    ;}
+  {name: "ceil"                    ; impl: @mplBuiltinCeil                    ;}
+  {name: "codeRef"                 ; impl: @mplBuiltinCodeRef                 ;}
+  {name: "cos"                     ; impl: @mplBuiltinCos                     ;}
+  #{name: "cref"                    ; impl: @mplBuiltinCref                    ;}
+  {name: "compileOnce"             ; impl: @mplBuiltinCompileOnce             ;}
+  {name: "COMPILER_VERSION"        ; impl: @mplBuiltinCompilerVersion         ;}
+  {name: "const"                   ; impl: @mplBuiltinConst                   ;}
+  {name: "copy"                    ; impl: @mplBuiltinCopy                    ;}
+  {name: "DEBUG"                   ; impl: @mplBuiltinDebug                   ;}
+  {name: "def"                     ; impl: @mplBuiltinDef                     ;}
+  {name: "delete"                  ; impl: @mplBuiltinDelete                  ;}
+  #{name: "deref"                   ; impl: @mplBuiltinDeref                   ;}
+  #{name: "dirty"                   ; impl: @mplBuiltinDirty                   ;}
+  {name: "dynamic"                 ; impl: @mplBuiltinDirty                   ;}
+  {name: "exportFunction"          ; impl: @mplBuiltinExportFunction          ;}
+  {name: "exportVariable"          ; impl: @mplBuiltinExportVariable          ;}
+  {name: "FALSE"                   ; impl: @mplBuiltinFalse                   ;}
+  {name: "failProc"                ; impl: @mplBuiltinFailProc                ;}
+  {name: "fieldCount"              ; impl: @mplBuiltinFieldCount              ;}
+  {name: "fieldIndex"              ; impl: @mplBuiltinFieldIndex              ;}
+  {name: "fieldName"               ; impl: @mplBuiltinFieldName               ;}
+  {name: "floor"                   ; impl: @mplBuiltinFloor                   ;}
+  {name: "has"                     ; impl: @mplBuiltinHas                     ;}
+  {name: "HAS_LOGS"                ; impl: @mplBuiltinHasLogs                 ;}
+  {name: "if"                      ; impl: @mplBuiltinIf                      ;}
+  {name: "is"                      ; impl: @mplBuiltinIs                      ;}
+  {name: "isMoved"                 ; impl: @mplBuiltinIsMoved                 ;}
+  {name: "importFunction"          ; impl: @mplBuiltinImportFunction          ;}
+  {name: "importVariable"          ; impl: @mplBuiltinImportVariable          ;}
+  {name: "includeModule"           ; impl: @mplBuiltinIncludeModule           ;}
+  {name: "isConst"                 ; impl: @mplBuiltinIsConst                 ;}
+  {name: "isCombined"              ; impl: @mplBuiltinIsCombined              ;}
+  {name: "LF"                      ; impl: @mplBuiltinLF                      ;}
+  {name: "log"                     ; impl: @mplBuiltinLog                     ;}
+  {name: "log10"                   ; impl: @mplBuiltinLog10                   ;}
+  {name: "loop"                    ; impl: @mplBuiltinLoop                    ;}
+  {name: "lshift"                  ; impl: @mplBuiltinLShift                  ;}
+  {name: "manuallyInitVariable"    ; impl: @mplBuiltinManuallyInitVariable    ;}
+  {name: "manuallyDestroyVariable" ; impl: @mplBuiltinManuallyDestroyVariable ;}
+  {name: "mod"                     ; impl: @mplBuiltinMod                     ;}
+  {name: "module"                  ; impl: @mplBuiltinModule                  ;}
+  {name: "move"                    ; impl: @mplBuiltinMove                    ;}
+  {name: "moveIf"                  ; impl: @mplBuiltinMoveIf                  ;}
+  {name: "neg"                     ; impl: @mplBuiltinNeg                     ;}
+  {name: "new"                     ; impl: @mplBuiltinNew                     ;}
+  {name: "newVarOfTheSameType"     ; impl: @mplBuiltinNewVarOfTheSameType     ;}
+  {name: "not"                     ; impl: @mplBuiltinNot                     ;}
+  {name: "or"                      ; impl: @mplBuiltinOr                      ;}
+  {name: "printCompilerMessage"    ; impl: @mplBuiltinPrintCompilerMessage    ;}
+  {name: "printStack"              ; impl: @mplBuiltinPrintStack              ;}
+  {name: "printStackTrace"         ; impl: @mplBuiltinPrintStackTrace         ;}
+  {name: "printVariableCount"      ; impl: @mplBuiltinPrintVariableCount      ;}
+  {name: "recursive"               ; impl: @mplBuiltinRecursive               ;}
+  #{name: "ref"                    ; impl: @mplBuiltinRef                    ;}
+  {name: "rshift"                  ; impl: @mplBuiltinRShift                  ;}
+  {name: "same"                    ; impl: @mplBuiltinSame                    ;}
+  {name: "schema"                  ; impl: @mplBuiltinSchema                  ;}
+  {name: "set"                     ; impl: @mplBuiltinSet                     ;}
+  {name: "sin"                     ; impl: @mplBuiltinSin                     ;}
+  {name: "sqrt"                    ; impl: @mplBuiltinSqrt                    ;}
+  {name: "static"                  ; impl: @mplBuiltinStatic                  ;}
+  {name: "storageSize"             ; impl: @mplBuiltinStorageSize             ;}
+  {name: "storageAddress"          ; impl: @mplBuiltinStorageAddress          ;}
+  {name: "textSize"                ; impl: @mplBuiltinTextSize                ;}
+  {name: "textSplit"               ; impl: @mplBuiltinTextSplit               ;}
+  {name: "TRUE"                    ; impl: @mplBuiltinTrue                    ;}
+  {name: "uif"                     ; impl: @mplBuiltinUif                     ;}
+  {name: "ucall"                   ; impl: @mplBuiltinUcall                   ;}
+  {name: "useModule"               ; impl: @mplBuiltinUseModule               ;}
+  {name: "virtual"                 ; impl: @mplBuiltinVirtual                 ;}
+  {name: "xor"                     ; impl: @mplBuiltinXor                     ;}
 );
 
 builtinFirst: [0 static] func;
@@ -125,27 +127,21 @@ initBuiltins: [
   currentNode: @codeNode;
   failProc: @failProcForProcessor;
 
-  initBuiltinsInRange: [
-    first:last: copy; copy;
-    i: first copy;
-    [
-      i last < [
-        i 2 * builtins @ call makeStringView i addBuiltin
-        i 1 + @i set
-        TRUE static
-      ] [
-        FALSE static
-      ] if
-    ] loop
-  ] func;
-
-  builtinMiddle: builtinFirst builtinLast + 2 /;
-  builtinFirst builtinMiddle initBuiltinsInRange
-  builtinMiddle builtinLast initBuiltinsInRange
+  builtins makeArrayRange [
+    p:;
+    p.value.name makeStringView p.index addBuiltin
+  ] each
 ] func;
 
-callBuiltin: [
-  builtinFirst builtinLast [
-    2 * 1 + builtins @ call
-  ] staticCall
-] func;
+{processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref; index: Int32;} () {convention: cdecl;} [
+  processorResult:;
+  processor:;
+  copy indexOfNode:;
+  currentNode:;
+  multiParserResult:;
+  failProc: @failProcForProcessor;
+  copy index:;
+
+  builtinFunc: index builtins @ .@impl;
+  multiParserResult @currentNode indexOfNode @processor @processorResult @builtinFunc call
+] "callBuiltinImpl" exportFunction

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -2966,7 +2966,6 @@ finalizeCodeNode: [
     # we can call func as imported
     topIndex: indexOfNode copy;
     topNode: @currentNode;
-
     [topNode.parent 0 = not] [
       topNode.parent @topIndex set
       topIndex @processor.@nodes.at.get !topNode
@@ -3471,11 +3470,11 @@ astNodeToCodeNodeImpl: [
   failProc: @failProcForProcessor;
 
   processor.options.autoRecursion @codeNode.@nodeIsRecursive set
-  nodeCase @codeNode.@nodeCase set
-  parentIndex @codeNode.@parent set
-  @compilerPositionInfo @codeNode.@position set
-  getStackDepth @codeNode.@minStackDepth set
-  processor.varCount @codeNode.@variableCountDelta set
+  nodeCase                        @codeNode.@nodeCase set
+  parentIndex                     @codeNode.@parent set
+  @compilerPositionInfo           @codeNode.@position set
+  getStackDepth                   @codeNode.@minStackDepth set
+  processor.varCount              @codeNode.@variableCountDelta set
 
   processor.depthOfRecursion 1 + @processor.@depthOfRecursion set
   processor.depthOfRecursion processor.maxDepthOfRecursion > [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1333,7 +1333,7 @@ findNameStackObject: [
 getNameAs: [
   copy overload:;
   copy forMatching:;
-  matchingRef:;
+  matchingCapture:;
   copy nameInfo:;
   name: nameInfo processor.nameInfos.at.name;
 
@@ -1367,12 +1367,13 @@ getNameAs: [
         nameInfoEntry.nameCase   @result.@nameCase set
         nameInfoEntry.startPoint @result.@startPoint set
 
-        result.nameCase NameCaseSelfMember = [result.nameCase NameCaseClosureMember =] || [
+        nameCase: matchingCapture.captureCase NameCaseInvalid = [result.nameCase copy] [matchingCapture.captureCase copy] if;
+        nameCase NameCaseSelfMember = [nameCase NameCaseClosureMember =] || [
           object: nameInfoEntry.refToVar;
           overloadShift: curNameInfo.stack.dataSize 1 - overload -;
           fr: nameInfo object overloadShift findFieldWithOverloadShift;
           fr.success [
-            object result.nameCase MemberCaseToObjectCase findLocalObject @result.@object set
+            object nameCase MemberCaseToObjectCase findLocalObject @result.@object set
             fr.index @result.@mplFieldIndex set
             fr.index VarStruct object getVar.data.get .get .fields.at .refToVar @result.@refToVar set
             object.mutable @result.@refToVar.@mutable set
@@ -1380,11 +1381,11 @@ getNameAs: [
             unknownName
           ] if
         ] [
-          result.nameCase NameCaseSelfObject = [result.nameCase NameCaseClosureObject =] || [
+          nameCase NameCaseSelfObject = [nameCase NameCaseClosureObject =] || [
             forMatching [
-              overload curNameInfo.stack.at matchingRef result.nameCase findNameStackObject @result.@refToVar set
+              overload curNameInfo.stack.at matchingCapture.refToVar nameCase findNameStackObject @result.@refToVar set
             ] [
-              nameInfoEntry.refToVar result.nameCase findLocalObject @result.@refToVar set
+              nameInfoEntry.refToVar nameCase findLocalObject @result.@refToVar set
             ] if
           ] [
             nameInfoEntry.refToVar @result.@refToVar set
@@ -1424,12 +1425,12 @@ getNameAs: [
   result
 ] func;
 
-getName: [RefToVar FALSE dynamic -1 dynamic getNameAs] func;
+getName: [Capture FALSE dynamic -1 dynamic getNameAs] func;
 getNameForMatching: [TRUE dynamic -1 dynamic getNameAs] func;
 
 getNameWithOverload: [
   copy overload:;
-  RefToVar FALSE dynamic overload getNameAs
+  Capture FALSE dynamic overload getNameAs
 ] func;
 
 getNameForMatchingWithOverload: [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -3442,6 +3442,12 @@ astNodeToCodeNodeImpl: [
 
   processor.depthOfRecursion 255 > [
     "max depth of recursion (256) exceeded" makeStringView compilerError
+    TRUE dynamic @processor.@maxDepthExceeded set
+  ] when
+
+  processor.depthOfPre 64 > [
+    "max depth of PRE recursion (64) exceeded" makeStringView compilerError
+    TRUE dynamic @processor.@maxDepthExceeded set
   ] when
 
   addr: indexArray storageAddress;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -2939,27 +2939,12 @@ finalizeCodeNode: [
   ] each
 
   String @currentNode.@irName set
-  hasForcedSignature [processor.options.pointerSize 32nx =] && [
-    forcedSignature.convention (
-      ConventionCdecl []
-      ConventionStd   ["x86_stdcallcc "  toString @currentNode.@convention set]
-      ConventionFast  ["x86_fastcallcc " toString @currentNode.@convention set]
-      []
-    ) case
+  hasForcedSignature [forcedSignature.convention "" = not] && [
+    (forcedSignature.convention " ") assembleString @currentNode.@convention set
+    forcedSignature.convention @currentNode.@mplConvention set
   ] [
     String @currentNode.@convention set
-  ] if
-
-  hasForcedSignature [
-    forcedSignature.convention (
-      ConventionMpl   ["mpl"   toString @currentNode.@mplConvention set]
-      ConventionCdecl ["cdecl" toString @currentNode.@mplConvention set]
-      ConventionStd   ["std"   toString @currentNode.@mplConvention set]
-      ConventionFast  ["fast"  toString @currentNode.@mplConvention set]
-      [[FALSE] "Unknown convention!" assert]
-    ) case
-  ] [
-    "mpl" toString @currentNode.@mplConvention set
+    "-" toString @currentNode.@mplConvention set
   ] if
 
   (retType "(" signature ")") assembleString @currentNode.@signature set

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -2956,7 +2956,7 @@ finalizeCodeNode: [
     forcedSignature.convention @currentNode.@mplConvention set
   ] [
     String @currentNode.@convention set
-    "-" toString @currentNode.@mplConvention set
+    "" toString @currentNode.@mplConvention set
   ] if
 
   (retType "(" signature ")") assembleString @currentNode.@signature set

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -3441,6 +3441,11 @@ addMatchingNode: [
   ] if
 ] func;
 
+nodeHasCode: [
+  node:;
+  node.emptyDeclaration not [node.empty not] && [node.deleted not] && [node.nodeCase NodeCaseCodeRefDeclaration = not] &&
+] func;
+
 astNodeToCodeNodeImpl: [
   forcedSignature:;
   compilerPositionInfo:;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -3528,14 +3528,17 @@ astNodeToCodeNodeImpl: [
     processor.depthOfRecursion @processor.@maxDepthOfRecursion set
   ] when
 
-  processor.depthOfRecursion 255 > [
-    "max depth of recursion (256) exceeded" makeStringView compilerError
-    TRUE dynamic @processor.@maxDepthExceeded set
+  maxDepthOfRecursion: 256;
+  maxDepthOfPre:       64;
+
+  processor.depthOfRecursion maxDepthOfRecursion > [
+    ("max depth of recursion (" maxDepthOfRecursion ") exceeded") assembleString compilerError
+    TRUE dynamic @processorResult.@maxDepthExceeded set
   ] when
 
-  processor.depthOfPre 64 > [
-    "max depth of PRE recursion (64) exceeded" makeStringView compilerError
-    TRUE dynamic @processor.@maxDepthExceeded set
+  processor.depthOfPre maxDepthOfPre > [
+    ("max depth of PRE recursion (" maxDepthOfPre ") exceeded") assembleString compilerError
+    TRUE dynamic @processorResult.@maxDepthExceeded set
   ] when
 
   addr: indexArray storageAddress;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1873,9 +1873,9 @@ tryImplicitLambdaCast: [
       astNode: VarCode refToSrc getVar.data.get @multiParserResult.@memory.at;
       astNode: VarCode refToSrc getVar.data.get @multiParserResult.@memory.at;
       index: csignature astNode name makeStringView TRUE dynamic processExportFunction;
-      lambdaNode: index processor.nodes.at.get;
 
       compilable [
+        lambdaNode: index processor.nodes.at.get;
         gnr: lambdaNode.varNameInfo getName;
         compilable not [
           [FALSE] "Name of new lambda is not visible!" assert

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -810,7 +810,13 @@ setOneVar: [
     staticness: refSrc staticnessOfVar;
     staticness Weak = [refDst staticnessOfVar @staticness set] when
     staticness @dstVar.@staticness set
-  ] when
+  ] [
+    srcVar.data.getTag VarRef = [refSrc.mutable copy] && [VarRef srcVar.data.get.mutable copy] && [
+      staticness: refSrc staticnessOfVar;
+      refSrc makeVarTreeDirty
+      staticness @srcVar.@staticness set
+    ] when
+  ] if
 ] func;
 
 setVar: [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -694,6 +694,7 @@ copyOneVarWith: [
   dstVar: dst getVar;
   srcVar.irTypeId  @dstVar.@irTypeId set
   srcVar.mplTypeId @dstVar.@mplTypeId set
+  srcVar.dbgTypeId @dstVar.@dbgTypeId set
 
   dst
 ] func;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -2722,7 +2722,7 @@ finalizeCodeNode: [
             ] if;
 
             needToCopy [current.refToVar argAbleToCopy not] && [isRealFunction copy] && [
-              "getting huge agrument by copy; fast's export function can not have this signature" compilerError
+              "getting huge agrument by copy; mpl's export function can not have this signature" compilerError
             ] when
 
             needToCopy [
@@ -2769,7 +2769,7 @@ finalizeCodeNode: [
         isDeclaration [output isTinyArg [hasRet not] &&] ||;
 
         passAsRet not [isRealFunction copy] && [
-          "returning two arguments or non-primitive object; fast's function can not have this signature" compilerError
+          "returning two arguments or non-primitive object; mpl's function can not have this signature" compilerError
         ] when
 
         compilable [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -33,7 +33,7 @@ compilable: [processorResult.success copy] func;
   processor: Processor Ref;
   indexOfNode: Int32;
   currentNode: CodeNode Ref;
-  multiParserResult: MultiParserResult Cref; 
+  multiParserResult: MultiParserResult Cref;
   positionInfo: CompilerPositionInfo Cref;
   name: StringView Cref;
   nodeCase: NodeCaseCode;
@@ -54,7 +54,7 @@ compilable: [processorResult.success copy] func;
   processor: Processor Ref;
   indexOfNode: Int32;
   currentNode: CodeNode Ref;
-  multiParserResult: MultiParserResult Cref; 
+  multiParserResult: MultiParserResult Cref;
   refToVar: RefToVar Cref;
 } () {convention: cdecl;} "processFuncPtrImpl" importFunction
 
@@ -3097,7 +3097,7 @@ finalizeCodeNode: [
   ] func;
 
   noname: hasForcedSignature not;
-    #[currentNode.nodeCase NodeCaseLambda =] ||;
+  #[currentNode.nodeCase NodeCaseLambda =] ||;
 
   currentNode.nodeCase NodeCaseEmpty = [
     noname

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -2811,7 +2811,7 @@ finalizeCodeNode: [
       current: i currentNode.buildingMatchingInfo.captures.at;
       current.argCase ArgRef = [
         isRealFunction [
-          "real function can not have local captures" compilerError
+          ("real function can not have local capture; name=" current.nameInfo processor.nameInfos.at.name) assembleString compilerError
         ] when
         current.refToVar FALSE addRefArg
       ] [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -993,6 +993,7 @@ makeVirtualVarReal: [
       FALSE @result.@mutable set
       result @realValue set
     ] when
+
     realValue copy
   ] if
 ] func;
@@ -2832,8 +2833,9 @@ finalizeCodeNode: [
       current: i currentNode.buildingMatchingInfo.captures.at;
       current.argCase ArgRef = [
         isRealFunction [
-          ("real function can not have local capture; name=" current.nameInfo processor.nameInfos.at.name) assembleString compilerError
+          ("real function can not have local capture; name=" current.nameInfo processor.nameInfos.at.name "; type=" current.refToVar getMplType) assembleString compilerError
         ] when
+
         current.refToVar FALSE addRefArg
       ] [
         current.argCase ArgGlobal = [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -2838,8 +2838,13 @@ finalizeCodeNode: [
 
   currentNode.variadic [
     isDeclaration [
-      ", ..." @signature.cat
-      ", ..." @argumentList.cat
+      currentNode.buildingMatchingInfo.inputs.getSize 0 = [
+        "..." @signature.cat
+        "..." @argumentList.cat
+      ] [
+        ", ..." @signature.cat
+        ", ..." @argumentList.cat
+      ] if
     ] [
       "export function cannot be variadic" compilerError
     ] if

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -899,7 +899,7 @@ makeVirtualVarReal: [
         refToVar @unfinishedSrc.pushBack
         result @unfinishedDst.pushBack
 
-        result untemporize
+        # result untemporize
         # first pass: make new variable type
         [
           unfinishedSrc.dataSize 0 > [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1872,7 +1872,6 @@ tryImplicitLambdaCast: [
       csignature: declarationNode.csignature;
       name: ("lambda." processor.nodes.getSize) assembleString;
       astNode: VarCode refToSrc getVar.data.get @multiParserResult.@memory.at;
-      astNode: VarCode refToSrc getVar.data.get @multiParserResult.@memory.at;
       index: csignature astNode name makeStringView TRUE dynamic processExportFunction;
 
       compilable [

--- a/debugWriter.mpl
+++ b/debugWriter.mpl
@@ -141,7 +141,7 @@ addMemberInfo: [
   name: field.nameInfo processor.nameInfos.at.name makeStringView;
 
   name "" = [
-    ("!" index " = !DIDerivedType(tag: DW_TAG_member, name: \"[" fieldNumber "]\", scope: !" currentNode.funcDbgIndex
+    ("!" index " = !DIDerivedType(tag: DW_TAG_member, name: \"f" fieldNumber "\", scope: !" currentNode.funcDbgIndex
       ", file: !" currentNode.position.filename processor.debugInfo.fileNameIds.at
       ", line: " currentNode.position.line ", baseType: !" fr.value ", size: " fsize 8 * ", offset: " offset 8 * ")") assembleString
   ] [
@@ -212,7 +212,7 @@ getTypeDebugDeclaration: [
             processor.debugInfo.lastId 1 + @processor.@debugInfo.@lastId set
 
             ("!" index " = distinct !DICompositeType(tag: DW_TAG_structure_type, file: !" currentNode.position.filename processor.debugInfo.fileNameIds.at
-              ", name: \"" refToVar getMplType "\", line: " currentNode.position.line ", size: " refToVar getStorageSize 0ix cast 0 cast 8 * ", elements: !" index 1 -
+              ", name: \"" refToVar getDebugType "\", line: " currentNode.position.line ", size: " refToVar getStorageSize 0ix cast 0 cast 8 * ", elements: !" index 1 -
               ")") assembleString @processor.@debugInfo.@strings.pushBack
             index currentNode.funcDbgIndex @processor.@debugInfo.@locationIds.insert
             index

--- a/debugWriter.mpl
+++ b/debugWriter.mpl
@@ -406,7 +406,7 @@ correctUnitInfo: [
   globals: index copy;
 
   ("!" processor.debugInfo.unit " = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !" lastUnit processor.debugInfo.fileNameIds.at
-    ", producer: \"fast compiler\", isOptimized: false, runtimeVersion: 2, emissionKind: FullDebug, globals: !" globals ")") assembleString
+    ", producer: \"mpl compiler\", isOptimized: false, runtimeVersion: 2, emissionKind: FullDebug, globals: !" globals ")") assembleString
   processor.debugInfo.unitStringNumber @processor.@debugInfo.@strings.at set
 
   ("!llvm.dbg.cu = !{!" processor.debugInfo.unit "}") assembleString

--- a/defaultImpl.mpl
+++ b/defaultImpl.mpl
@@ -1,0 +1,155 @@
+"defaultImpl" module
+"control" includeModule
+
+failProcForProcessor: [
+  failProc: [stringMemory printAddr " - fail while handling fail" stringMemory printAddr] func;
+  copy message:;
+  "ASSERTION FAILED!!!" print LF print
+  message print LF print
+  "While compiling:" print LF print
+  defaultPrintStackTrace
+
+  "Terminating..." print LF print
+  2 exit
+] func;
+
+defaultFailProc: [
+  text: pop;
+] func;
+
+defaultCall: [
+  refToVar: pop;
+  compilable [
+    var: refToVar getVar;
+    var.data.getTag VarCode = [
+      VarCode var.data.get "call" makeStringView processCall
+    ] [
+      var.data.getTag VarImport = [
+        refToVar processFuncPtr
+      ] [
+        refToVar isCallable [
+          RefToVar refToVar "call" makeStringView callCallableStruct # call struct with INVALID object
+        ] [
+          "not callable" makeStringView compilerError
+        ] if
+      ] if
+    ] if
+  ] when
+] func;
+
+defaultSet: [
+  refToDst: pop;
+  refToSrc: pop;
+
+  compilable [
+    refToDst refToSrc variablesAreSame [
+      refToSrc getVar.data.getTag VarImport = [
+        "functions cannot be copied" compilerError
+      ] [
+        refToDst.mutable [
+          [refToDst staticnessOfVar Weak = not] "Destination is weak!" assert
+          refToSrc refToDst createCopyToExists
+        ] [
+          "destination is immutable" compilerError
+        ] if
+      ] if
+    ] [
+      refToDst.mutable not [
+        "destination is immutable" compilerError
+      ] [
+        lambdaCastResult: refToSrc refToDst tryImplicitLambdaCast;
+        lambdaCastResult.success [
+          newSrc: lambdaCastResult.refToVar TRUE createRef;
+          newSrc refToDst createCopyToExists
+        ] [
+          ("types mismatch, src is " refToSrc getMplType "," LF "dst is " refToDst getMplType) assembleString compilerError
+        ] if
+      ] if
+    ] if
+  ] when
+] func;
+
+defaultRef: [
+  copy mutable:;
+  refToVar: pop;
+  compilable [
+    refToVar mutable createRef push
+  ] when
+] func;
+
+defaultMakeConstWith: [
+  copy check:;
+  refToVar: pop;
+  compilable [
+    check [refToVar getVar.temporary copy] && [
+      "temporary objects cannot be set const" compilerError
+    ] [
+      FALSE @refToVar.@mutable set
+      refToVar push
+    ] if
+  ] when
+] func;
+
+defaultUseOrIncludeModule: [
+  copy asUse:;
+  (
+    [compilable]
+    [currentNode.parent  0 = not ["module can be used only in top node" compilerError] when]
+    [refToName: pop;]
+    [refToName staticnessOfVar Weak < ["name must be static string" compilerError] when]
+    [
+      varName: refToName getVar;
+      varName.data.getTag VarString = not ["name must be static string" compilerError] when
+    ] [
+      string: VarString varName.data.get;
+      fr: string makeStringView processor.modules.find;
+      fr.success [fr.value 0 < not] && [
+        frn: fr.value currentNode.usedModulesTable.find;
+        frn2: fr.value currentNode.directlyIncludedModulesTable.find;
+        frn.success frn2.success or [
+          ("duplicate use module: " string) assembleString compilerError
+        ] [
+          fr.value asUse processUseModule
+        ] if
+      ] [
+        TRUE dynamic @processorResult.@findModuleFail set
+        string @processorResult.@errorInfo.@missedModule set
+        ("module not found: " string) assembleString compilerError
+      ] if
+    ]
+  ) sequence
+] func;
+
+defaultPrintStack: [
+  ("stack:" LF "depth=" getStackDepth LF) printList
+
+  i: 0 dynamic;
+  [
+    i getStackDepth < [
+      entry: i getStackEntryUnchecked;
+      (i getStackEntryUnchecked getMplType entry.mutable ["R" makeStringView]["C" makeStringView] if LF) printList
+      i 1 + @i set TRUE
+    ] &&
+  ] loop
+] func;
+
+defaultPrintStackTrace: [
+  nodeIndex: indexOfNode copy;
+  [
+    node: nodeIndex processor.nodes.at.get;
+    node.root [
+      FALSE
+    ] [
+      ("at filename: "  node.position.filename processor.options.fileNames.at
+        ", token: "      node.position.token
+        ", nodeIndex: "  nodeIndex
+        ", line: "       node.position.line
+        ", column: "     node.position.column LF) printList
+
+      node.parent @nodeIndex set
+      TRUE
+    ] if
+  ] loop
+
+  defaultPrintStack
+] func;

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -462,6 +462,7 @@ createRetValue: [
 
 createCallIR: [
   funcName:;
+  conventionName:;
   argList:;
   refToRet:;
 
@@ -473,9 +474,9 @@ createCallIR: [
   haveRet [
     generateRegisterIRName @retName set
 
-    ("  " @retName getNameById " = call " refToRet getIrType " ") @operation.catMany
+    ("  " @retName getNameById " = call " conventionName refToRet getIrType " ") @operation.catMany
   ] [
-    "  call void " @operation.cat
+    ("  call " conventionName "void ") @operation.catMany
   ] if
 
   @funcName @operation.cat

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -21,7 +21,6 @@ createDerefToRegister: [
 
 createAllocIR: [
   refToVar:;
-
   var: refToVar getVar;
 
   currentNode.parent 0 = [

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -36,6 +36,15 @@ createAllocIR: [
   refToVar copy
 ] func;
 
+createStaticInitIR: [
+  refToVar:;
+  var: refToVar getVar;
+  [currentNode.parent 0 =] "Can be used only with global vars!" assert
+  (refToVar getIrName " = local_unnamed_addr global " refToVar getStaticStructIR) assembleString @processor.@prolog.pushBack
+  processor.prolog.dataSize 1 - @var.@globalDeclarationInstructionIndex set
+  refToVar copy
+] func;
+
 createVarImportIR: [
   refToVar:;
 

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -80,6 +80,13 @@ createGlobalAliasIR: [
   (alias getNameById " = alias " aliaseeType getNameById ", " aliaseeType getNameById "* " aliasee getNameById) assembleString @processor.@prolog.pushBack
 ] func;
 
+createFuncAliasIR: [
+  aliaseeType:;
+  aliasee:;
+  alias:;
+  (alias " = ifunc " aliaseeType ", " aliaseeType "* " aliasee) assembleString
+] func;
+
 createStoreConstant: [
   refToDst:;
   refWithValue:;
@@ -680,4 +687,15 @@ sortInstructions: [
   @fakePointersAllocs [.@value move @currentNode.@program.pushBack] each
   @fakePointers       [.@value move @currentNode.@program.pushBack] each
   @noallocs           [.@value move @currentNode.@program.pushBack] each
+] func;
+
+addAliasesForUsedNodes: [
+  String @processor.@prolog.pushBack
+  "; Func aliases" toString @processor.@prolog.pushBack
+  @processor.@nodes [
+    currentNode: .@value.get;
+    currentNode nodeHasCode [
+      @currentNode.@aliases [.@value move @processor.@prolog.pushBack] each
+    ] when
+  ] each
 ] func;

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -1,5 +1,7 @@
 "irWriter" module
-"control" useModule
+
+"control" includeModule
+"defaultImpl" includeModule
 
 IRArgument: [{
   irTypeId: 0;
@@ -232,10 +234,10 @@ createFailWithMessage: [
 
   failProcRefToVar getVar.data.getTag VarBuiltin = [
     #no overload
-    mplBuiltinFailProc
+    defaultFailProc
   ] [
     failProcRefToVar derefAndPush
-    mplBuiltinCall
+    defaultCall
   ] if
 ] func;
 

--- a/main.mpl
+++ b/main.mpl
@@ -230,32 +230,35 @@ createDefinition: [
 
             processorResult.success [
               outputFileName @processorResult.@program saveString [
-                ("program written to " makeStringView outputFileName makeStringView) addLog
+                ("program written to " outputFileName) addLog
               ] [
-                ("failed to save program" makeStringView) addLog
+                ("failed to save program" LF) printList
+                FALSE @success set
               ] if
             ] [
-              processorResult.errorInfo.position.dataSize 0 = [
-                ("error, "  processorResult.errorInfo.message) printList LF print
-              ] [
-                i: 0 dynamic;
-                [
-                  i processorResult.errorInfo.position.dataSize < [
-                    nodePosition: i processorResult.errorInfo.position.at;
+              processorResult.globalErrorInfo [
+                pair:;
+                current: pair.value;
+                pair.index 0 > [LF print] when 
+                current.position.getSize 0 = [
+                  ("error, "  current.message) printList LF print
+                ] [
+                  current.position [
+                    pair:;
+                    i: pair.index;
+                    nodePosition: pair.value;
                     (nodePosition.filename options.fileNames.at "(" nodePosition.line  ","  nodePosition.column "): ") printList
 
                     i 0 = [
-                      ("error, [" nodePosition.token "], " processorResult.errorInfo.message) printList LF print
+                      ("error, [" nodePosition.token "], " current.message LF) printList
                     ] [
-                      ("[" nodePosition.token "], called from here") printList LF print
+                      ("[" nodePosition.token "], called from here" LF) printList
                     ] if
+                  ] each
+                ] if
 
-                    i 1 + @i set TRUE
-                  ] &&
-                ] loop
-              ] if
-
-              FALSE @success set
+                FALSE @success set
+              ] each
             ] if
           ] when
         ] if

--- a/main.mpl
+++ b/main.mpl
@@ -71,7 +71,7 @@ createDefinition: [
   ] if
 ] func;
 
-{argc: 0; argv: 0nx;} 0 {} [
+{argc: 0; argv: 0nx;} 0 {convention: "cdecl";} [
   ("Start mplc compiler") addLog
   [
     argc:;

--- a/main.mpl
+++ b/main.mpl
@@ -239,7 +239,7 @@ createDefinition: [
               processorResult.globalErrorInfo [
                 pair:;
                 current: pair.value;
-                pair.index 0 > [LF print] when 
+                pair.index 0 > [LF print] when
                 current.position.getSize 0 = [
                   ("error, "  current.message) printList LF print
                 ] [

--- a/main.mpl
+++ b/main.mpl
@@ -23,7 +23,7 @@ printInfo: [
   "  -linker_option      Add linker option for LLVM" print LF print
   "  -logs               Value of \"HAS_LOGS\" constant in code turn to TRUE" print LF print
   "  -ndebug             Disable debug info; value of \"DEBUG\" constant in code turn to FALSE" print LF print
-  "  -o <file>           Write output to <file>, default output file is \"fast.ll\"" print LF print
+  "  -o <file>           Write output to <file>, default output file is \"mpl.ll\"" print LF print
   "  -statlit            Number literals are static constants, which are used in analysis; default mode is static literals" print LF print
   "  -verbose_ir         Print information about current token in IR" print LF print
   "  -version            Print compiler version while compiling" print LF print
@@ -84,7 +84,7 @@ createDefinition: [
     success: TRUE dynamic;
     fileNames: String Array;
     linkerOptions: String Array;
-    outputFileName: "fast.ll" toString;
+    outputFileName: "mpl.ll" toString;
 
     options: ProcessorOptions;
     optOutputFileName: FALSE dynamic;
@@ -186,16 +186,16 @@ createDefinition: [
       fileNames.getSize 1 = [
         hasVersion [
           DEBUG [
-            ("MPL Fast compiler version " COMPILER_SOURCE_VERSION " debug" LF) printList
+            ("MPL compiler version " COMPILER_SOURCE_VERSION " debug" LF) printList
           ] [
-            ("MPL Fast compiler version " COMPILER_SOURCE_VERSION LF) printList
+            ("MPL compiler version " COMPILER_SOURCE_VERSION LF) printList
           ] if
         ] [
           "No input files" print LF print
         ] if
       ] [
         hasVersion [
-          ("MPL Fast compiler version " COMPILER_SOURCE_VERSION LF) printList
+          ("MPL compiler version " COMPILER_SOURCE_VERSION LF) printList
           "Input files ignored" print LF print
         ] [
           fileNames [

--- a/main.mpl
+++ b/main.mpl
@@ -71,7 +71,7 @@ createDefinition: [
   ] if
 ] func;
 
-{argc: 0; argv: 0nx;} 0 {convention: "cdecl";} [
+{argc: 0; argv: 0nx;} 0 {convention: cdecl;} [
   ("Start mplc compiler") addLog
   [
     argc:;

--- a/main.mpl
+++ b/main.mpl
@@ -7,10 +7,6 @@
 "processorImpl" useModule
 "file" useModule
 
-
-# self command: ../fast/astNodeType.fast ../fast/astOptimizers.fast ../fast/builtinImpl.fast ../fast/builtins.fast ../fast/codeNode.fast ../fast/debugWriter.fast ../fast/irWriter.fast ../fast/main.fast ../fast/parser.fast ../fast/pathUtils.fast ../fast/printAST.fast ../fast/processor.fast ../fast/processorImpl.fast ../fast/processSubNodes.fast ../fast/staticCall.fast ../fast/variable.fast ../sl/array.fast ../sl/control.fast ../sl/file.fast ../sl/hashTable.fast ../sl/memory.fast ../sl/owner.fast ../sl/string.fast ../sl/variant.fast
-# sl args: ../sl/array.fast ../sl/control.fast ../sl/file.fast ../sl/hashTable.fast ../sl/memory.fast ../sl/owner.fast ../sl/string.fast ../sl/variant.fast
-
 printInfo: [
   "USAGE: mplc.exe [options] <inputs>" print LF print
   "OPTIONS:" print LF print

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -253,7 +253,10 @@ tryMatchNode: [
   ] &&;
 
   invisibleName: currentMatchingNode.nodeCase NodeCaseLambda = [currentMatchingNode.varNameInfo 0 < not] && [
-    gnr: currentMatchingNode.varNameInfo currentMatchingNode.refToVar getNameForMatching;
+    matchingCapture: Capture;
+    currentMatchingNode.refToVar @matchingCapture.@refToVar set
+    NameCaseLocal                @matchingCapture.@captureCase set
+    gnr: currentMatchingNode.varNameInfo matchingCapture getNameForMatching;
     gnr.refToVar.hostId 0 <
   ] &&;
 
@@ -335,7 +338,7 @@ tryMatchNode: [
           currentCapture: i currentMatchingNode.matchingInfo.captures.at;
           cacheEntry: currentCapture.refToVar;
           overload: currentCapture getOverload;
-          stackEntry: currentCapture.nameInfo cacheEntry overload getNameForMatchingWithOverload.refToVar;
+          stackEntry: currentCapture.nameInfo currentCapture overload getNameForMatchingWithOverload.refToVar;
 
           stackEntry.hostId 0 < not [stackEntry cacheEntry compareEntriesRec] && [
             i 1 + @i set
@@ -752,9 +755,8 @@ applyNodeChanges: [
       cacheEntry: currentCapture.refToVar;
       overload: currentCapture getOverload;
 
-      #("capture; name=" currentCapture.nameInfo processor.nameInfos.at.name "; type=" cacheEntry getMplType
-      #  "; ce=" cacheEntry.hostId ":" cacheEntry.varId ":" cacheEntry isGlobal) addLog
-      stackEntry: currentCapture.nameInfo cacheEntry overload getNameForMatchingWithOverload captureName.refToVar;
+      stackEntry: currentCapture.nameInfo currentCapture overload getNameForMatchingWithOverload captureName.refToVar;
+      #("capture; name=" currentCapture.nameInfo processor.nameInfos.at.name "; ctype=" cacheEntry getMplType "; stype=" stackEntry getMplType) addLog
       #("capture; se=" stackEntry.hostId ":" stackEntry.varId ":" stackEntry isGlobal) addLog
       stackEntry cacheEntry applyEntriesRec
       i 1 + @i set compilable
@@ -990,7 +992,7 @@ makeCallInstructionWith: [
 
       currentCapture.argCase ArgRef = [
         overload: currentCapture getOverload;
-        refToVar: currentCapture.nameInfo currentCapture.refToVar overload getNameForMatchingWithOverload captureName.refToVar;
+        refToVar: currentCapture.nameInfo currentCapture overload getNameForMatchingWithOverload captureName.refToVar;
         [currentCapture.refToVar refToVar variablesAreSame] "invalid capture type while generating arg list!" assert
 
         arg: IRArgument;

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -1058,7 +1058,20 @@ processCallByIndexArray: [
   ] when
 
   compilable [
-    newNodeIndex processCallByNode
+    newNode: newNodeIndex @processor.@nodes.at.get;
+    currentNode.parent 0 = [nodeCase NodeCaseList = nodeCase NodeCaseObject = or] && [newNode.matchingInfo.inputs.getSize 0 =] && [newNode.outputs.getSize 1 =] && [
+      realCapturesCount: 0;
+      newNode.matchingInfo.captures [.value.refToVar isVirtual not [realCapturesCount 1 + @realCapturesCount set] when] each
+      realCapturesCount 0 =
+    ] && [
+      0 newNode.outputs.at.refToVar isStaticData
+    ] && [
+      result: 0 newNode.outputs.at.refToVar copyVarFromChild;
+      TRUE @newNode.@deleted set
+      result createStaticInitIR push
+    ] [
+      newNodeIndex processCallByNode
+    ] if
   ] when
 ] func;
 

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -911,7 +911,7 @@ derefNEntries: [
   i: 0 dynamic;
   [
     i count < [
-      i implicitDerefInfo.at [
+      count 1 - i - implicitDerefInfo.at [
         dst: i getStackEntry;
         dst getPossiblePointee @dst set
       ] when

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -293,14 +293,14 @@ tryMatchNode: [
     [getStackDepth currentMatchingNode.matchingInfo.inputs.dataSize currentMatchingNode.matchingInfo.preInputs.dataSize + < not] &&
   ] &&;
 
-  goodReality: 
-    forceRealFunction not [
-      currentMatchingNode.nodeCase NodeCaseDeclaration =
-      [currentMatchingNode.nodeCase NodeCaseDllDeclaration =] ||
-      [currentMatchingNode.nodeCase NodeCaseCodeRefDeclaration =] ||
-      [currentMatchingNode.nodeCase NodeCaseExport =] ||
-      [currentMatchingNode.nodeCase NodeCaseLambda =] ||
-    ] ||;
+  goodReality:
+  forceRealFunction not [
+    currentMatchingNode.nodeCase NodeCaseDeclaration =
+    [currentMatchingNode.nodeCase NodeCaseDllDeclaration =] ||
+    [currentMatchingNode.nodeCase NodeCaseCodeRefDeclaration =] ||
+    [currentMatchingNode.nodeCase NodeCaseExport =] ||
+    [currentMatchingNode.nodeCase NodeCaseLambda =] ||
+  ] ||;
 
   invisibleName: currentMatchingNode.nodeCase NodeCaseLambda = [currentMatchingNode.varNameInfo 0 < not] && [
     matchingCapture: Capture;
@@ -1201,7 +1201,7 @@ processCallByNode: [
   forcedName processNamedCallByNode
 ] func;
 
-{processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref; 
+{processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref;
   positionInfo: CompilerPositionInfo Cref; name: StringView Cref; nodeCase: NodeCaseCode; indexArray: IndexArray Cref;} () {convention: cdecl;} [
 
   processorResult:;
@@ -1962,7 +1962,7 @@ nSwap: [
   name:;
   astNode:;
   signature:;
-  
+
   indexArray: AstNodeType.Code astNode.data.get;
   positionInfo: astNode makeCompilerPosition;
   compileOnce
@@ -2231,7 +2231,7 @@ callImportWith: [
 
 callImport: [RefToVar FALSE dynamic callImportWith] func;
 
-{processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref; 
+{processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref;
   refToVar: RefToVar Cref;} () {convention: cdecl;} [
 
   processorResult:;

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -1761,31 +1761,33 @@ processExportFunction: [
     processor.processingExport 1 - @processor.@processingExport set
   ] when
 
-  newNode: newNodeIndex processor.nodes.at.get;
-  newNode.outputs.getSize 1 > ["export function cant have 2 or more outputs" compilerError] when
-  newNode.outputs.getSize 1 = [signature.outputs.getSize 0 =] && ["signature is void, export function must be without output" compilerError] when
-  newNode.outputs.getSize 0 = [signature.outputs.getSize 1 =] && ["signature is not void, export function must have output" compilerError] when
-
   compilable [
-    newNode.captureNames [
-      currentCaptureName: .value;
-      currentCaptureName.startPoint indexOfNode = not [
-        #("use cap from module " currentCaptureName.startPoint " while get name " currentCaptureName.nameInfo processor.nameInfos.at.name " type " refToVar getMplType) addLog
-        fr: currentCaptureName.startPoint @currentNode.@usedModulesTable.find;
-        fr.success [TRUE @fr.@value.@used set] when
-      ] when
-    ] each
+    newNode: newNodeIndex processor.nodes.at.get;
+    newNode.outputs.getSize 1 > ["export function cant have 2 or more outputs" compilerError] when
+    newNode.outputs.getSize 1 = [signature.outputs.getSize 0 =] && ["signature is void, export function must be without output" compilerError] when
+    newNode.outputs.getSize 0 = [signature.outputs.getSize 1 =] && ["signature is not void, export function must have output" compilerError] when
 
-    signature.outputs [
-      pair:;
-      currentInNode: pair.index newNode.outputs.at.refToVar;
-      currentInSignature: pair.value;
+    compilable [
+      newNode.captureNames [
+        currentCaptureName: .value;
+        currentCaptureName.startPoint indexOfNode = not [
+          #("use cap from module " currentCaptureName.startPoint " while get name " currentCaptureName.nameInfo processor.nameInfos.at.name " type " refToVar getMplType) addLog
+          fr: currentCaptureName.startPoint @currentNode.@usedModulesTable.find;
+          fr.success [TRUE @fr.@value.@used set] when
+        ] when
+      ] each
 
-      currentInNode currentInSignature variablesAreSame not [
-        ("export function output mismatch, expected " currentInSignature getMplType ";" LF
-          "but found " currentInNode getMplType) assembleString compilerError
-      ] when
-    ] each
+      signature.outputs [
+        pair:;
+        currentInNode: pair.index newNode.outputs.at.refToVar;
+        currentInSignature: pair.value;
+
+        currentInNode currentInSignature variablesAreSame not [
+          ("export function output mismatch, expected " currentInSignature getMplType ";" LF
+            "but found " currentInNode getMplType) assembleString compilerError
+        ] when
+      ] each
+    ] when
   ] when
 
   signature.inputs [p:; a: pop;] each

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -1247,9 +1247,13 @@ processPre: [
     newNodeIndex: indexArray tryMatchAllNodes;
     newNodeIndex 0 < [compilable] && [
       oldSuccess: compilable;
+      oldGlobalErrorCount: processorResult.globalErrorInfo.getSize;
+
       processor.depthOfPre 1 + @processor.@depthOfPre set
       "PRE" makeStringView indexOfNode NodeCaseCode  @processorResult @processor indexArray multiParserResult positionInfo CFunctionSignature astNodeToCodeNode @newNodeIndex set
       processor.depthOfPre 1 - @processor.@depthOfPre set
+
+      oldGlobalErrorCount @processorResult.@globalErrorInfo.shrink
 
       oldSuccess [
         processor.maxDepthExceeded not [
@@ -1900,11 +1904,13 @@ processExportFunction: [
     "export function cannot be variadic" compilerError
   ] when
 
+  oldSuccess: compilable;
   newNodeIndex: @indexArray TRUE dynamic tryMatchAllNodesWith;
   newNodeIndex 0 < [compilable] && [
     nodeCase: asLambda [NodeCaseLambda][NodeCaseExport] if;
     processor.processingExport 1 + @processor.@processingExport set
     name indexOfNode nodeCase @processorResult @processor indexArray multiParserResult positionInfo signature astNodeToCodeNode @newNodeIndex set
+
     processor.processingExport 1 - @processor.@processingExport set
   ] when
 
@@ -1944,6 +1950,12 @@ processExportFunction: [
         ] when
       ] each
     ] when
+  ] when
+
+  oldSuccess compilable not and [
+    @processorResult.@errorInfo move @processorResult.@globalErrorInfo.pushBack
+    ProcessorErrorInfo @processorResult.@errorInfo set
+    TRUE dynamic @processorResult.@success set
   ] when
 
   signature.inputs [p:; a: pop;] each

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -1096,8 +1096,10 @@ processPre: [
       processor.depthOfPre 1 - @processor.@depthOfPre set
 
       oldSuccess [
-        ProcessorErrorInfo @processorResult.@errorInfo set
-        TRUE dynamic @processorResult.@success set
+        processor.maxDepthExceeded not [
+          ProcessorErrorInfo @processorResult.@errorInfo set
+          TRUE dynamic @processorResult.@success set
+        ] when
       ] [
         [FALSE] "Has compilerError before trying compiling pre!" assert
       ] if
@@ -1764,6 +1766,7 @@ processExportFunction: [
   ] when
 
   signature.inputs [p:; a: pop;] each
+  ("processed export: " makeStringView name makeStringView) addLog
 
   newNodeIndex
 ] func;

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -712,7 +712,7 @@ fixCaptureRef: [
   result
 ] func;
 
-applyPreNodeCaptures: [
+usePreCaptures: [
   compileOnce
   currentChangesNode:;
 
@@ -760,6 +760,7 @@ applyNodeChanges: [
     i currentChangesNode.matchingInfo.inputs.dataSize < [
       stackEntry: popForMatching;
       cacheEntry: i currentChangesNode.matchingInfo.inputs.at.refToVar;
+
       stackEntry cacheEntry applyEntriesRec
       stackEntry @pops.pushBack
 
@@ -1222,7 +1223,7 @@ processPre: [
 
     newNode: newNodeIndex processor.nodes.at.get;
     newNode usePreInputs
-    newNode applyPreNodeCaptures
+    newNode usePreCaptures
     #newNode useCapturesAsPreCaptures
     #newNode usePreCaptures
 
@@ -1882,6 +1883,13 @@ processExportFunction: [
           fr.success [TRUE @fr.@value.@used set] when
         ] when
       ] each
+
+      newNode usePreCaptures
+
+      #newNode.matchingInfo.captures [
+      #  capture: .value;
+      #  ("capture; name=" capture.nameInfo processor.nameInfos.at.name "; ctype=" capture.refToVar getMplType) addLog
+      #] each
 
       signature.outputs [
         pair:;

--- a/processor.mpl
+++ b/processor.mpl
@@ -300,6 +300,7 @@ Processor: [{
 
   usedFloatBuiltins: FALSE dynamic;
   usedHeapBuiltins: FALSE dynamic;
+  maxDepthExceeded: FALSE dynamic;
 
   INIT: [];
   DIE: [];

--- a/processor.mpl
+++ b/processor.mpl
@@ -200,7 +200,6 @@ CodeNode: [{
   emptyDeclaration: FALSE dynamic;
   uncompilable: FALSE dynamic;
   variadic: FALSE dynamic;
-  #positionInfo: CompilerPositionInfo;
 
   declarationRefs: Cond Array;
   buildingMatchingInfo: MatchingInfo;

--- a/processor.mpl
+++ b/processor.mpl
@@ -54,11 +54,6 @@ ArgReturn:        [4n8 dynamic] func;
 ArgRefDeref:      [5n8 dynamic] func;
 ArgReturnDeref:   [6n8 dynamic] func;
 
-ConventionMpl:   [0n8 dynamic] func;
-ConventionCdecl: [1n8 dynamic] func;
-ConventionStd:   [2n8 dynamic] func;
-ConventionFast:  [3n8 dynamic] func;
-
 Argument: [{
   refToVar: RefToVar;
   argCase: ArgRef;
@@ -162,7 +157,7 @@ CFunctionSignature: [{
   inputs: RefToVar Array;
   outputs: RefToVar Array;
   variadic: FALSE dynamic;
-  convention: ConventionMpl dynamic;
+  convention: String;
 }] func;
 
 UsedModuleInfo: [{

--- a/processor.mpl
+++ b/processor.mpl
@@ -54,6 +54,11 @@ ArgReturn:        [4n8 dynamic] func;
 ArgRefDeref:      [5n8 dynamic] func;
 ArgReturnDeref:   [6n8 dynamic] func;
 
+ConventionMpl:   [0n8 dynamic] func;
+ConventionCdecl: [1n8 dynamic] func;
+ConventionStd:   [2n8 dynamic] func;
+ConventionFast:  [3n8 dynamic] func;
+
 Argument: [{
   refToVar: RefToVar;
   argCase: ArgRef;
@@ -155,9 +160,9 @@ MatchingInfo: [{
 
 CFunctionSignature: [{
   inputs: RefToVar Array;
-  void: FALSE dynamic;
-  output: RefToVar;
+  outputs: RefToVar Array;
   variadic: FALSE dynamic;
+  convention: ConventionMpl dynamic;
 }] func;
 
 UsedModuleInfo: [{
@@ -186,6 +191,8 @@ CodeNode: [{
   header: String;
   argTypes: String;
   csignature: CFunctionSignature;
+  convention: String;
+  mplConvention: String;
   signature: String;
   nodeCompileOnce: FALSE dynamic;
   empty: FALSE dynamic;
@@ -218,7 +225,8 @@ CodeNode: [{
   usedOrIncludedModulesTable: Int32 Cond HashTable; # moduleID, hasUsedVars
 
   refToVar: RefToVar; #refToVar of this node
-  varName: -1 dynamic; #variable name of imported function
+  varNameInfo: -1 dynamic; #variable name of imported function
+  moduleId: -1 dynamic;
   namedFunctions: String Int32 HashTable; # name -> node ID
   capturedVars: RefToVar Array;
   funcDbgIndex: -1 dynamic;
@@ -253,6 +261,7 @@ Processor: [{
   capturesNameInfo:            -1 dynamic;
   variadicNameInfo:            -1 dynamic;
   failProcNameInfo:            -1 dynamic;
+  conventionNameInfo:          -1 dynamic;
 
   globalVarCount:    0 dynamic;
   globalVarId:       0 dynamic;

--- a/processor.mpl
+++ b/processor.mpl
@@ -33,6 +33,7 @@ ProcessorErrorInfo: [{
 ProcessorResult: [{
   success: TRUE dynamic;
   findModuleFail: FALSE dynamic;
+  maxDepthExceeded: FALSE dynamic;
   program: String;
   errorInfo: ProcessorErrorInfo;
   globalErrorInfo: ProcessorErrorInfo Array;
@@ -308,7 +309,6 @@ Processor: [{
 
   usedFloatBuiltins: FALSE dynamic;
   usedHeapBuiltins: FALSE dynamic;
-  maxDepthExceeded: FALSE dynamic;
 
   INIT: [];
   DIE: [];

--- a/processor.mpl
+++ b/processor.mpl
@@ -35,6 +35,7 @@ ProcessorResult: [{
   findModuleFail: FALSE dynamic;
   program: String;
   errorInfo: ProcessorErrorInfo;
+  globalErrorInfo: ProcessorErrorInfo Array;
 }] func;
 
 makeInstruction: [{

--- a/processor.mpl
+++ b/processor.mpl
@@ -1,5 +1,6 @@
 "processor" module
-"control" useModule
+"control" includeModule
+"astNodeType" includeModule
 
 CompilerPositionInfo: [{
   column: -1 dynamic;

--- a/processor.mpl
+++ b/processor.mpl
@@ -173,6 +173,7 @@ CodeNode: [{
   stack: RefToVar Array; # we must compile node without touching parent
   minStackDepth: 0 dynamic;
   program: Instruction Array;
+  aliases: String Array;
   variables: Variable Owner Array; # as unique_ptr...
 
   nodeIsRecursive: FALSE dynamic;
@@ -257,8 +258,9 @@ Processor: [{
   failProcNameInfo:            -1 dynamic;
   conventionNameInfo:          -1 dynamic;
 
-  globalVarCount:    0 dynamic;
-  globalVarId:       0 dynamic;
+  funcAliasCount:     0 dynamic;
+  globalVarCount:     0 dynamic;
+  globalVarId:        0 dynamic;
   globalInitializer: -1 dynamic; # index of func for calling all initializers
   globalDestructibleVars: RefToVar Array;
   processingExport: 0 dynamic;

--- a/processor.mpl
+++ b/processor.mpl
@@ -175,6 +175,8 @@ CodeNode: [{
   program: Instruction Array;
   aliases: String Array;
   variables: Variable Owner Array; # as unique_ptr...
+  lastLambdaName: Int32;
+  nextRecLambdaId: -1 dynamic;
 
   nodeIsRecursive: FALSE dynamic;
   nextLabelIsVirtual: FALSE dynamic;

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -44,6 +44,18 @@ failProcForProcessor: [
   refToVar: RefToVar Cref;
 } () {convention: cdecl;} "createDtorForGlobalVar" importFunction
 
+clearProcessorResult: [
+  copy cachedGlobalErrorInfoSize:;
+  TRUE dynamic              @processorResult.@success set
+  FALSE dynamic             @processorResult.@findModuleFail set
+  FALSE dynamic             @processorResult.@maxDepthExceeded set
+  String                    @processorResult.@program set
+  ProcessorErrorInfo        @processorResult.@errorInfo set
+  cachedGlobalErrorInfoSize 0 < not [
+    cachedGlobalErrorInfoSize @processorResult.@globalErrorInfo.shrink
+  ] when
+] func;
+
 processImpl: [
   processorResult:;
   copy unitId:;
@@ -121,14 +133,6 @@ processImpl: [
     dependedFiles: String IndexArray HashTable; # string -> array of indexes of dependent files
     cachedGlobalErrorInfoSize: 0;
 
-    clearProcessorResult: [
-      TRUE dynamic              @processorResult.@success set
-      FALSE dynamic             @processorResult.@findModuleFail set
-      String                    @processorResult.@program set
-      ProcessorErrorInfo        @processorResult.@errorInfo set
-      cachedGlobalErrorInfoSize @processorResult.@globalErrorInfo.shrink
-    ] func;
-
     runFile: [
       copy n:;
       n @lastFile set
@@ -153,7 +157,7 @@ processImpl: [
           @processorResult.@errorInfo.@missedModule @a move @dependedFiles.insert
         ] if
 
-        clearProcessorResult
+        cachedGlobalErrorInfoSize clearProcessorResult
       ] [
         ("compiled file " n processor.options.fileNames.at) addLog
         # call files which depends from this module
@@ -208,7 +212,7 @@ processImpl: [
         lastFile correctUnitInfo
       ] when
 
-      clearProcessorResult
+      0 clearProcessorResult
 
       dependedFiles.getSize 0 > [
         hasError: FALSE dynamic;

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -261,6 +261,7 @@ processImpl: [
     createCtors
     createDtors
     clearUnusedDebugInfo
+    addAliasesForUsedNodes
 
     i: 0 dynamic;
     [
@@ -275,8 +276,7 @@ processImpl: [
     [
       i processor.nodes.dataSize < [
         currentNode: i @processor.@nodes.at.get;
-
-        currentNode.emptyDeclaration not [currentNode.empty not] && [currentNode.deleted not] && [currentNode.nodeCase NodeCaseCodeRefDeclaration = not] && [
+        currentNode nodeHasCode [
           LF makeStringView @processorResult.@program.cat
 
           currentNode.header makeStringView @processorResult.@program.cat

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -33,7 +33,7 @@ failProcForProcessor: [
   nodeCase: NodeCaseCode;
   parentIndex: 0;
   functionName: StringView Cref;
-} 0 {convention: "cdecl";} "astNodeToCodeNode" importFunction
+} 0 {convention: cdecl;} "astNodeToCodeNode" importFunction
 
 {
   signature: CFunctionSignature Cref;
@@ -42,7 +42,7 @@ failProcForProcessor: [
   processor: Processor Ref;
   processorResult: ProcessorResult Ref;
   refToVar: RefToVar Cref;
-} () {convention: "cdecl";} "createDtorForGlobalVar" importFunction
+} () {convention: cdecl;} "createDtorForGlobalVar" importFunction
 
 processImpl: [
   processorResult:;
@@ -323,7 +323,7 @@ processImpl: [
   unitId: 0;
   options: ProcessorOptions Cref;
   multiParserResult: MultiParserResult Cref;
-} () {convention: "cdecl";} [
+} () {convention: cdecl;} [
   processorResult:;
   unitId:;
   options:;
@@ -344,7 +344,7 @@ processImpl: [
   nodeCase: NodeCaseCode;
   parentIndex: 0;
   functionName: StringView Cref;
-} 0 {convention: "cdecl";}  [
+} 0 {convention: cdecl;}  [
   signature:;
   compilerPositionInfo:;
   multiParserResult:;
@@ -409,7 +409,7 @@ createDtorForGlobalVarImpl: [
   processor: Processor Ref;
   processorResult: ProcessorResult Ref;
   refToVar: RefToVar Cref;
-} () {convention: "cdecl";} [
+} () {convention: cdecl;} [
   forcedSignature:;
   compilerPositionInfo:;
   multiParserResult:;

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -231,8 +231,7 @@ processImpl: [
 
 
   ("all nodes generated" makeStringView) addLog
-
-  [processor.recursiveNodesStack.getSize 0 =] "Recursive stack is not empty!" assert
+  [compilable not [processor.recursiveNodesStack.getSize 0 =] ||] "Recursive stack is not empty!" assert
 
   processorResult.success [
     #("; total used="           memoryUsed

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -33,7 +33,7 @@ failProcForProcessor: [
   nodeCase: NodeCaseCode;
   parentIndex: 0;
   functionName: StringView Cref;
-} 0 {} "astNodeToCodeNode" importFunction
+} 0 {convention: "cdecl";} "astNodeToCodeNode" importFunction
 
 {
   signature: CFunctionSignature Cref;
@@ -42,7 +42,7 @@ failProcForProcessor: [
   processor: Processor Ref;
   processorResult: ProcessorResult Ref;
   refToVar: RefToVar Cref;
-} () {} "createDtorForGlobalVar" importFunction
+} () {convention: "cdecl";} "createDtorForGlobalVar" importFunction
 
 processImpl: [
   processorResult:;
@@ -64,19 +64,20 @@ processImpl: [
     key id @processor.@nameInfos.at.@name set
   ] each
 
-  ""         findNameInfo @processor.@emptyNameInfo set
-  "CALL"     findNameInfo @processor.@callNameInfo set
-  "PRE"      findNameInfo @processor.@preNameInfo set
-  "DIE"      findNameInfo @processor.@dieNameInfo set
-  "INIT"     findNameInfo @processor.@initNameInfo set
-  "ASSIGN"   findNameInfo @processor.@assignNameInfo set
-  "self"     findNameInfo @processor.@selfNameInfo set
-  "closure"  findNameInfo @processor.@closureNameInfo set
-  "inputs"   findNameInfo @processor.@inputsNameInfo set
-  "outputs"  findNameInfo @processor.@outputsNameInfo set
-  "captures" findNameInfo @processor.@capturesNameInfo set
-  "variadic" findNameInfo @processor.@variadicNameInfo set
-  "failProc" findNameInfo @processor.@failProcNameInfo set
+  ""           findNameInfo @processor.@emptyNameInfo set
+  "CALL"       findNameInfo @processor.@callNameInfo set
+  "PRE"        findNameInfo @processor.@preNameInfo set
+  "DIE"        findNameInfo @processor.@dieNameInfo set
+  "INIT"       findNameInfo @processor.@initNameInfo set
+  "ASSIGN"     findNameInfo @processor.@assignNameInfo set
+  "self"       findNameInfo @processor.@selfNameInfo set
+  "closure"    findNameInfo @processor.@closureNameInfo set
+  "inputs"     findNameInfo @processor.@inputsNameInfo set
+  "outputs"    findNameInfo @processor.@outputsNameInfo set
+  "captures"   findNameInfo @processor.@capturesNameInfo set
+  "variadic"   findNameInfo @processor.@variadicNameInfo set
+  "failProc"   findNameInfo @processor.@failProcNameInfo set
+  "convention" findNameInfo @processor.@conventionNameInfo set
 
   addCodeNode
   TRUE dynamic @processor.@nodes.last.get.@root set
@@ -322,7 +323,7 @@ processImpl: [
   unitId: 0;
   options: ProcessorOptions Cref;
   multiParserResult: MultiParserResult Cref;
-} () {} [
+} () {convention: "cdecl";} [
   processorResult:;
   unitId:;
   options:;
@@ -343,7 +344,7 @@ processImpl: [
   nodeCase: NodeCaseCode;
   parentIndex: 0;
   functionName: StringView Cref;
-} 0 {}  [
+} 0 {convention: "cdecl";}  [
   signature:;
   compilerPositionInfo:;
   multiParserResult:;
@@ -408,7 +409,7 @@ createDtorForGlobalVarImpl: [
   processor: Processor Ref;
   processorResult: ProcessorResult Ref;
   refToVar: RefToVar Cref;
-} () {} [
+} () {convention: "cdecl";} [
   forcedSignature:;
   compilerPositionInfo:;
   multiParserResult:;

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -11,52 +11,12 @@
 "processor" useModule
 "irWriter" useModule
 
-failProcForProcessor: [
-  failProc: [stringMemory printAddr " - fail while handling fail" stringMemory printAddr] func;
-  copy message:;
-  "ASSERTION FAILED!!!" print LF print
-  message print LF print
-  "While compiling:" print LF print
-  mplBuiltinPrintStackTrace
-
-  "Terminating..." print LF print
-  2 exit
-] func;
-
 {
-  signature: CFunctionSignature Cref;
-  compilerPositionInfo: CompilerPositionInfo Cref;
-  multiParserResult: MultiParserResult Cref;
-  indexArray: IndexArray Cref;
-  processor: Processor Ref;
   processorResult: ProcessorResult Ref;
-  nodeCase: NodeCaseCode;
-  parentIndex: 0;
-  functionName: StringView Cref;
-} 0 {convention: cdecl;} "astNodeToCodeNode" importFunction
-
-{
-  signature: CFunctionSignature Cref;
-  compilerPositionInfo: CompilerPositionInfo Cref;
+  unitId: 0;
+  options: ProcessorOptions Cref;
   multiParserResult: MultiParserResult Cref;
-  processor: Processor Ref;
-  processorResult: ProcessorResult Ref;
-  refToVar: RefToVar Cref;
-} () {convention: cdecl;} "createDtorForGlobalVar" importFunction
-
-clearProcessorResult: [
-  copy cachedGlobalErrorInfoSize:;
-  TRUE dynamic              @processorResult.@success set
-  FALSE dynamic             @processorResult.@findModuleFail set
-  FALSE dynamic             @processorResult.@maxDepthExceeded set
-  String                    @processorResult.@program set
-  ProcessorErrorInfo        @processorResult.@errorInfo set
-  cachedGlobalErrorInfoSize 0 < not [
-    cachedGlobalErrorInfoSize @processorResult.@globalErrorInfo.shrink
-  ] when
-] func;
-
-processImpl: [
+} () {convention: cdecl;} [
   processorResult:;
   copy unitId:;
   options:;
@@ -337,57 +297,16 @@ processImpl: [
       ] when
     ] each
   ] when
-] func;
-
-{
-  processorResult: ProcessorResult Ref;
-  unitId: 0;
-  options: ProcessorOptions Cref;
-  multiParserResult: MultiParserResult Cref;
-} () {convention: cdecl;} [
-  processorResult:;
-  unitId:;
-  options:;
-  multiParserResult:;
-  multiParserResult
-  options
-  unitId
-  @processorResult processImpl
 ] "process" exportFunction
 
 {
   signature: CFunctionSignature Cref;
   compilerPositionInfo: CompilerPositionInfo Cref;
   multiParserResult: MultiParserResult Cref;
-  indexArray: IndexArray Cref;
   processor: Processor Ref;
   processorResult: ProcessorResult Ref;
-  nodeCase: NodeCaseCode;
-  parentIndex: 0;
-  functionName: StringView Cref;
-} 0 {convention: cdecl;}  [
-  signature:;
-  compilerPositionInfo:;
-  multiParserResult:;
-  indexArray:;
-  processor:;
-  processorResult:;
-  nodeCase:;
-  parentIndex:;
-  functionName:;
-
-  functionName
-  parentIndex
-  nodeCase
-  @processorResult
-  @processor
-  indexArray
-  multiParserResult
-  compilerPositionInfo
-  signature astNodeToCodeNodeImpl
-] "astNodeToCodeNode" exportFunction
-
-createDtorForGlobalVarImpl: [
+  refToVar: RefToVar Cref;
+} () {convention: cdecl;} [
   forcedSignature:;
   compilerPositionInfo:;
   multiParserResult:;
@@ -421,21 +340,4 @@ createDtorForGlobalVarImpl: [
   dtorName: ("dtor." refToVar getVar.globalId) assembleString;
   dtorNameStringView: dtorName makeStringView;
   dtorNameStringView finalizeCodeNode
-] func;
-
-{
-  signature: CFunctionSignature Cref;
-  compilerPositionInfo: CompilerPositionInfo Cref;
-  multiParserResult: MultiParserResult Cref;
-  processor: Processor Ref;
-  processorResult: ProcessorResult Ref;
-  refToVar: RefToVar Cref;
-} () {convention: cdecl;} [
-  forcedSignature:;
-  compilerPositionInfo:;
-  multiParserResult:;
-  processor:;
-  processorResult:;
-  refToVar:;
-  refToVar @processorResult @processor multiParserResult compilerPositionInfo forcedSignature createDtorForGlobalVarImpl
 ] "createDtorForGlobalVar" exportFunction

--- a/variable.mpl
+++ b/variable.mpl
@@ -809,8 +809,8 @@ getFuncMplType: [
     "[" @result.cat
     i: 0;
     [
-      i args.dataSize < [
-        current: i args.at.refToVar;
+      i args.getSize < [
+        current: i args.at;
         current getMplType                                            @result.cat
         i 1 + args.getSize < [
           ","                                                         @result.cat
@@ -823,8 +823,8 @@ getFuncMplType: [
 
   "-"                @result.cat
   node.mplConvention @result.cat
-  node.matchingInfo.inputs catData
-  node.outputs catData
+  node.csignature.inputs catData
+  node.csignature.outputs catData
 
   resultId: @result makeStringId;
   resultId getNameById

--- a/variable.mpl
+++ b/variable.mpl
@@ -195,14 +195,15 @@ getVar: [
 ] func;
 
 getNameById: [processor.nameBuffer.at makeStringView] func;
-getMplName: [getVar.mplNameId getNameById] func;
-getIrName: [getVar.irNameId getNameById] func;
-getMplType: [getVar.mplTypeId getNameById] func;
-getIrType: [getVar.irTypeId getNameById] func;
-getDbgType: [getVar.dbgTypeId getNameById] func;
+getMplName:  [getVar.mplNameId getNameById] func;
+getIrName:   [getVar.irNameId getNameById] func;
+getMplType:  [getVar.mplTypeId getNameById] func;
+getIrType:   [getVar.irTypeId getNameById] func;
+getDbgType:  [getVar.dbgTypeId getNameById] func;
 
 getDebugType: [
-  splitted: getDbgType.split;
+  dbgType: getDbgType;
+  splitted: dbgType.split;
   splitted.success [
     splitted.chars.getSize 1024 > [
       1024 @splitted.@chars.shrink
@@ -211,7 +212,9 @@ getDebugType: [
   ] [
     ("Wrong dbgType name encoding" splitted.chars assembleString) assembleString compilerError
   ] if
-  splitted.chars assembleString
+  result: (dbgType hash ".") assembleString;
+  splitted.chars @result.catMany
+  @result
 ] func;
 
 deepPrintVar: [
@@ -956,8 +959,10 @@ makeVariableType: [
               curField.refToVar isVirtual not [
                 (
                   curField.nameInfo processor.nameInfos.at.name ":"
-                  curField.refToVar getDbgType ";") assembleString @resultDBG.cat
-              ] when
+                  curField.refToVar getDbgType ";") @resultDBG.catMany
+              ] [
+                (curField.nameInfo processor.nameInfos.at.name ".") @resultDBG.catMany
+              ] if
               i 1 + @i set TRUE
             ] &&
           ] loop

--- a/variable.mpl
+++ b/variable.mpl
@@ -928,7 +928,6 @@ makeVariableType: [
             ("[" branch.fields.dataSize " x " 0 branch.fields.at.refToVar getIrType "]") assembleString @resultIR.cat
           ] [
             "{" @resultIR.cat
-
             firstGood: TRUE;
             i: 0 dynamic;
             [
@@ -946,7 +945,6 @@ makeVariableType: [
             ] loop
             "}" @resultIR.cat
           ] if
-          #@resultIR makeTypeAlias
 
           "{" @resultDBG.cat
           i: 0 dynamic;

--- a/variable.mpl
+++ b/variable.mpl
@@ -204,8 +204,8 @@ getDbgType: [getVar.dbgTypeId getNameById] func;
 getDebugType: [
   splitted: getDbgType.split;
   splitted.success [
-    splitted.chars.getSize 256 > [
-      256 @splitted.@chars.shrink
+    splitted.chars.getSize 1024 > [
+      1024 @splitted.@chars.shrink
       "..." makeStringView @splitted.@chars.pushBack
     ] when
   ] [
@@ -871,15 +871,16 @@ makeVariableType: [
 
       branch getIrType @resultIR.cat
       "*"  @resultIR.cat
-      "*"  @resultDBG.cat
 
       branch getMplType @resultMPL.cat
-      branch getDbgType @resultDBG.cat
       branch.mutable [
         "R" @resultMPL.cat
       ] [
         "C" @resultMPL.cat
       ] if
+
+      branch getDbgType @resultDBG.cat
+      "*"  @resultDBG.cat
     ] [
       var.data.getTag VarStruct = [
         branch: VarStruct @var.@data.get.get;

--- a/variable.mpl
+++ b/variable.mpl
@@ -819,6 +819,8 @@ getFuncMplType: [
     "]" @result.cat
   ] func;
 
+  "-"                @result.cat
+  node.mplConvention @result.cat
   node.matchingInfo.inputs catData
   node.outputs catData
 

--- a/variable.mpl
+++ b/variable.mpl
@@ -4,6 +4,9 @@
 "Variant"   includeModule
 "Owner"     includeModule
 
+"irWriter" includeModule
+"debugWriter" includeModule
+
 Dirty:           [0n8 dynamic] func;
 Dynamic:         [1n8 dynamic] func;
 Weak:            [2n8 dynamic] func;

--- a/variable.mpl
+++ b/variable.mpl
@@ -809,7 +809,6 @@ getFuncMplType: [
       i args.dataSize < [
         current: i args.at.refToVar;
         current getMplType                                            @result.cat
-        #current.mutable ["R" makeStringView]["C" makeStringView] if   @result.cat
         i 1 + args.getSize < [
           ","                                                         @result.cat
         ] when


### PR DESCRIPTION
## Language changes
* ### Calling conventions support
  An options object in function signatures can now specify a calling convention. The compiler passes conventions directly to LLVM IR without any checks. There are functions `cdecl` and `stdcall` in `mpl-sl/conventions.mpl` that return string constants for corresponding conventions. The list of supported calling conventions is available in [LLVM documentation](https://llvm.org/docs/LangRef.html#calling-conventions).
  #### Example:
  ```
  {} {} {convention: "ccc";} "test" importFunction
  ```
## Compiler changes
* ### Global static data storage
  The compiler places global static arrays in a global LLVM IR variable and initialises them in-place. 
* ### Independent compilation of real functions
  Previously, the compiler could report only one error per compilation. Errors from functions which have a user-defined signature do not stop a compilation now.
  #### Example:
   test.mpl:
   ```
   {} {} {convention: "ccc";} [
     test2: {} {} {convention: "ccc";} codeRef;
     [123] !test2
     [x:;] !test2
     [] !test2
     test2
   ] "test1" exportFunction

  {} {} {convention: "ccc";} [1 "" +] "test3" exportFunction
  ```
  command line:
  ```
  mplc.exe -o test.ll test.mpl
  ```
  output:
  ```
  test.mpl(3,10): error, [!test2], signature is void, export function must be without output
  test.mpl(7,11): [exportFunction], called from here
  
  test.mpl(4,5): error, [x:], stack underflow
  test.mpl(4,10): [!test2], called from here
  test.mpl(7,11): [exportFunction], called from here
  
  test.mpl(9,34): error, [+], second argument invalid
  test.mpl(9,45): [exportFunction], called from here
  ```
* ### Error report improvements:
  * added name and type of capture to the error message about a local capture in real function
  * fixed error messages about local exportFunction\exportVariable
* ### Bug fixes:
  * limited PRE recursion depth
  * dynamised all variable-dependent entities if a reference to that variable put in dynamic context
  * fixed order of writes to the type names in debug info
  * fixed IR for calls of variadic functions with no arguments
  * fixed crash when a code assigned to a reference to a variadic function
  * fixed crash when used-defined names "closure" and "self" shadow compiler-defined names
  * used PRE captures in matching
  * removed confusing compilation error when dynamic codeRef created inside the dynamic loop
  * fixed order of the dereferences of function outputs
  * removed confusing compilation error when virtual variable wrapped into a built-in list
  * made distinguishable function signatures with the same arguments type but different levels of indirection 
  * suppressed errors from PRE when one of the previous errors is recursion depth limit exceeding
